### PR TITLE
Update travis build gcc to 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - sh projects/scripts/travis-install.sh
   - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
 
-  - sudo apt-get update -qq git status
+  - sudo apt-get update -qq
 install:
   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq "g++-${GCC_VERSION}"; fi
   - if [ "$CXX" = "g++" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi


### PR DESCRIPTION
I was reading your tests using gcc and the builds errored from `unrecognized -std=c++11 option` errors. Seems like your gcc 4.8 update doesn't work and the build still uses the preinstalled 4.6. 

I have hardcoded the correct update on the `.travis.yml` file and the tests are compiled successfully. Anyway, the `rxcppv2_test` test halts with no output after just calling it, and travis aborts build after 10 minutes of no response. I'm still working on it.

If everything works as expected, I will put the GCC4.9 install on your `travis-install.sh` instead of hardcoding it on the travis yaml.
