### PR TITLE
Fix exit_recursed_scope_type dtor cleaning requestor early

### DIFF
--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -458,11 +458,18 @@ class schedulable : public schedulable_base
         public:
             ~exit_recursed_scope_type()
             {
+                if (that != nullptr) {
                     that->requestor = nullptr;
+                }
             }
             exit_recursed_scope_type(const recursed_scope_type* that)
                 : that(that)
             {
+            }
+            exit_recursed_scope_type(exit_recursed_scope_type && other) /*noexcept*/
+                : that(other.that)
+            {
+                other.that = nullptr;
             }
         };
     public:
@@ -480,9 +487,9 @@ class schedulable : public schedulable_base
             // no change in recursion scope
             return *this;
         }
-        std::shared_ptr<exit_recursed_scope_type> reset(const recurse& r) const {
+        exit_recursed_scope_type reset(const recurse& r) const {
             requestor = std::addressof(r.get_recursed());
-            return std::make_shared<exit_recursed_scope_type>(this);
+            return exit_recursed_scope_type(this);
         }
         bool is_recursed() const {
             return !!requestor;

--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -480,9 +480,9 @@ class schedulable : public schedulable_base
             // no change in recursion scope
             return *this;
         }
-        exit_recursed_scope_type reset(const recurse& r) const {
+        std::shared_ptr<exit_recursed_scope_type> reset(const recurse& r) const {
             requestor = std::addressof(r.get_recursed());
-            return exit_recursed_scope_type(this);
+            return std::make_shared<exit_recursed_scope_type>(this);
         }
         bool is_recursed() const {
             return !!requestor;

--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -466,7 +466,7 @@ class schedulable : public schedulable_base
                 : that(that)
             {
             }
-            exit_recursed_scope_type(exit_recursed_scope_type && other) /*noexcept*/
+            exit_recursed_scope_type(exit_recursed_scope_type && other) RXCPP_NOEXCEPT
                 : that(other.that)
             {
                 other.that = nullptr;


### PR DESCRIPTION
Because of disabled RVO, `exit_recursed_scope_type` destructor was called on return statement in `recursed_scope_type::reset`, making the call ineffective. This change allows to use it as intended when RVO is disabled.