### PR TITLE
adding test for nocompare observe_on

### DIFF
--- a/Rx/v2/test/operators/observe_on.cpp
+++ b/Rx/v2/test/operators/observe_on.cpp
@@ -165,7 +165,8 @@ SCENARIO("observe_on no-comparison", "[observe][observe_on]"){
                 [so, xs]() {
                     return xs
                          | rxo::observe_on(so)
-                         | rxo::map([](nocompare v){ return v.v; });
+                         | rxo::map([](nocompare v){ return v.v; })
+                         | rxo::as_dynamic();
                 }
             );
 


### PR DESCRIPTION
notification uses SFINAE to compile for value_types that do not have operator==

lets see if vc has a problem with this test