### PR TITLE
Remove static from observe_on_run_loop

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
@@ -316,8 +316,7 @@ public:
 };
 
 inline observe_on_one_worker observe_on_run_loop(const rxsc::run_loop& rl) {
-    static observe_on_one_worker r(rxsc::make_run_loop(rl));
-    return r;
+    return observe_on_one_worker(rxsc::make_run_loop(rl));
 }
 
 inline observe_on_one_worker observe_on_event_loop() {


### PR DESCRIPTION
The change allows to use different run loops during the program execution.