### PR TITLE
Fix doc target missing declarations errors

### DIFF
--- a/Rx/v2/examples/doxygen/amb.cpp
+++ b/Rx/v2/examples/doxygen/amb.cpp
@@ -30,7 +30,7 @@ SCENARIO("implicit amb sample"){
     printf("//! [implicit amb sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("threaded amb sample"){
     printf("//! [threaded amb sample]\n");

--- a/Rx/v2/examples/doxygen/buffer.cpp
+++ b/Rx/v2/examples/doxygen/buffer.cpp
@@ -35,7 +35,7 @@ SCENARIO("buffer count+skip sample"){
     printf("//! [buffer count+skip sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("buffer period+skip+coordination sample"){
     printf("//! [buffer period+skip+coordination sample]\n");

--- a/Rx/v2/examples/doxygen/combine_latest.cpp
+++ b/Rx/v2/examples/doxygen/combine_latest.cpp
@@ -17,7 +17,7 @@ SCENARIO("combine_latest sample"){
     printf("//! [combine_latest sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("Coordination combine_latest sample"){
     printf("//! [Coordination combine_latest sample]\n");

--- a/Rx/v2/examples/doxygen/concat_map.cpp
+++ b/Rx/v2/examples/doxygen/concat_map.cpp
@@ -22,7 +22,7 @@ SCENARIO("concat_map sample"){
     printf("//! [concat_map sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("threaded concat_map sample"){
     printf("//! [threaded concat_map sample]\n");

--- a/Rx/v2/examples/doxygen/flat_map.cpp
+++ b/Rx/v2/examples/doxygen/flat_map.cpp
@@ -22,7 +22,7 @@ SCENARIO("flat_map sample"){
     printf("//! [flat_map sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("threaded flat_map sample"){
     printf("//! [threaded flat_map sample]\n");

--- a/Rx/v2/examples/doxygen/from.cpp
+++ b/Rx/v2/examples/doxygen/from.cpp
@@ -13,7 +13,7 @@ SCENARIO("from sample"){
     printf("//! [from sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("threaded from sample"){
     printf("//! [threaded from sample]\n");

--- a/Rx/v2/examples/doxygen/group_by.cpp
+++ b/Rx/v2/examples/doxygen/group_by.cpp
@@ -23,7 +23,7 @@ SCENARIO("group_by sample"){
 }
 
 //! [group_by full intro]
-bool less(int v1, int v2){
+static bool less(int v1, int v2){
     return v1 < v2;
 }
 //! [group_by full intro]

--- a/Rx/v2/examples/doxygen/main.cpp
+++ b/Rx/v2/examples/doxygen/main.cpp
@@ -4,6 +4,9 @@
 #include <iostream>
 #include <thread>
 #include <string>
+
+#include "main.hpp"
+
 std::string get_pid() {
     std::stringstream s;
     s << std::this_thread::get_id();

--- a/Rx/v2/examples/doxygen/main.hpp
+++ b/Rx/v2/examples/doxygen/main.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+std::string get_pid();

--- a/Rx/v2/examples/doxygen/merge.cpp
+++ b/Rx/v2/examples/doxygen/merge.cpp
@@ -30,7 +30,7 @@ SCENARIO("implicit merge sample"){
     printf("//! [implicit merge sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("threaded merge sample"){
     printf("//! [threaded merge sample]\n");

--- a/Rx/v2/examples/doxygen/merge_delay_error.cpp
+++ b/Rx/v2/examples/doxygen/merge_delay_error.cpp
@@ -33,7 +33,7 @@ SCENARIO("implicit merge_delay_error sample"){
 	printf("//! [implicit merge_delay_error sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("threaded merge_delay_error sample"){
 	printf("//! [threaded merge_delay_error sample]\n");

--- a/Rx/v2/examples/doxygen/observe_on.cpp
+++ b/Rx/v2/examples/doxygen/observe_on.cpp
@@ -3,7 +3,7 @@
 #include "rxcpp/rx-test.hpp"
 #include "catch.hpp"
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("observe_on sample"){
     printf("//! [observe_on sample]\n");

--- a/Rx/v2/examples/doxygen/pairwise.cpp
+++ b/Rx/v2/examples/doxygen/pairwise.cpp
@@ -23,7 +23,7 @@ SCENARIO("pairwise short sample"){
     printf("//! [pairwise short sample]\n");
 }
 
-//std::string get_pid();
+//#include "main.hpp"
 //
 //SCENARIO("threaded flat_map sample"){
 //    printf("//! [threaded flat_map sample]\n");

--- a/Rx/v2/examples/doxygen/range.cpp
+++ b/Rx/v2/examples/doxygen/range.cpp
@@ -13,7 +13,7 @@ SCENARIO("range sample"){
     printf("//! [range sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("threaded range sample"){
     printf("//! [threaded range sample]\n");

--- a/Rx/v2/examples/doxygen/replay.cpp
+++ b/Rx/v2/examples/doxygen/replay.cpp
@@ -3,7 +3,7 @@
 #include "rxcpp/rx-test.hpp"
 #include "catch.hpp"
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("replay sample"){
     printf("//! [replay sample]\n");

--- a/Rx/v2/examples/doxygen/skip_until.cpp
+++ b/Rx/v2/examples/doxygen/skip_until.cpp
@@ -15,7 +15,7 @@ SCENARIO("skip_until sample"){
     printf("//! [skip_until sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("threaded skip_until sample"){
     printf("//! [threaded skip_until sample]\n");

--- a/Rx/v2/examples/doxygen/subscribe_on.cpp
+++ b/Rx/v2/examples/doxygen/subscribe_on.cpp
@@ -3,7 +3,7 @@
 #include "rxcpp/rx-test.hpp"
 #include "catch.hpp"
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("subscribe_on sample"){
     printf("//! [subscribe_on sample]\n");

--- a/Rx/v2/examples/doxygen/take_until.cpp
+++ b/Rx/v2/examples/doxygen/take_until.cpp
@@ -26,7 +26,7 @@ SCENARIO("take_until time sample"){
     printf("//! [take_until time sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("threaded take_until sample"){
     printf("//! [threaded take_until sample]\n");

--- a/Rx/v2/examples/doxygen/with_latest_from.cpp
+++ b/Rx/v2/examples/doxygen/with_latest_from.cpp
@@ -17,7 +17,7 @@ SCENARIO("with_latest_from sample"){
     printf("//! [with_latest_from sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("Coordination with_latest_from sample"){
     printf("//! [Coordination with_latest_from sample]\n");

--- a/Rx/v2/examples/doxygen/zip.cpp
+++ b/Rx/v2/examples/doxygen/zip.cpp
@@ -17,7 +17,7 @@ SCENARIO("zip sample"){
     printf("//! [zip sample]\n");
 }
 
-std::string get_pid();
+#include "main.hpp"
 
 SCENARIO("Coordination zip sample"){
     printf("//! [Coordination zip sample]\n");


### PR DESCRIPTION
Building the docs (e.g. with `ninja doc`) failed with GCC (e.g. GCC 7.3
under Fedora 27) with some missing declaration errors.

Example:

    ../Rx/v2/examples/doxygen/main.cpp:7:13: error: no previous
    declaration for ‘std::__cxx11::string get_pid()’
    [-Werror=missing-declarations]

Thus, this change adds a shared declaration for `get_pid()` that is
included by all users/the file where it's defined such that
accidental deviation in the signature are immediately noticed (as
compile error).

Similarly, the visibility of the example `less()` is changed to static
as it's only locally used.

With those changes the doc target succeeds again.