### PR TITLE
Small fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ install:
     if [ -n "$DOXYGEN_VERSION" ]; then
       DOXYGEN_DIR=${DEPS_DIR}/doxygen-${DOXYGEN_VERSION}
       if [[ -z "$(ls -A ${DOXYGEN_DIR})" ]]; then
-        DOXYGEN_URL="http://ftp.stack.nl/pub/users/dimitri/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
+        DOXYGEN_URL="https://downloads.sourceforge.net/doxygen/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
         mkdir -p ${DOXYGEN_DIR} && travis_retry wget --quiet -O - ${DOXYGEN_URL} | tar --strip-components=1 -xz -C ${DOXYGEN_DIR}
       fi
       export PATH=${DOXYGEN_DIR}/bin:${PATH}

--- a/Rx/v2/examples/doxygen/composite_exception.cpp
+++ b/Rx/v2/examples/doxygen/composite_exception.cpp
@@ -17,11 +17,11 @@ SCENARIO("composite_exception sample"){
             [](std::exception_ptr composite_e) {
                 printf("OnError %s\n", rxu::what(composite_e).c_str());
                 try { std::rethrow_exception(composite_e); }
-                catch(rxcpp::composite_exception ce) {
+                catch(rxcpp::composite_exception const &ce) {
                     for(std::exception_ptr particular_e : ce.exceptions) {
 
                         try{ std::rethrow_exception(particular_e); }
-                        catch(std::runtime_error error) { printf(" *** %s\n", error.what()); }
+                        catch(std::runtime_error const &error) { printf(" *** %s\n", error.what()); }
 
                     }
                 }


### PR DESCRIPTION
### Fix 'Wcatch-value'.
This warning is reported by GCC 9.

### Fix url to Doxygen binary tarball.
The files hosted on SourceForge are not going to fade away.