### PR TITLE
README: fix cmake generation snippet for clang/linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ make
 ```shell
 mkdir projects/build
 cd projects/build
-cmake -G"Unix Makefiles" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -B. ../CMake
+cmake -G"Unix Makefiles" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -B. ../CMake
 make
 ```
 


### PR DESCRIPTION
clang should be told to use libc++, otherwise it will
try to use libstdc++ which may be missing on some systems.

Resolves: #478