### PR TITLE
cmake: Fix 'make' generator targets

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -135,8 +135,12 @@ set(RX_SOURCES
 # Grouping all the source files puts them into a virtual folder in Visual Studio
 source_group("src" FILES ${RX_SOURCES})
 
+if (MSVC)
+# This 'RxCpp' build target only appears to be a virtual project for IDEs.
+# It won't actually build correctly since it is missing the shared.cmake integration.
 add_library(RxCpp SHARED ${RX_SOURCES})
 SET_TARGET_PROPERTIES(RxCpp PROPERTIES LINKER_LANGUAGE CXX)
+endif (MSVC)
 
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE CACHE BOOL "Don't require all projects to be built in order to install" FORCE)
 


### PR DESCRIPTION
Remove 'RxCpp' library target when it's used outside of
Visual Studio. This was supposed to be a virtual target,
not an actual one that builds libRxCpp.so.

The build never worked because it was missing setting the
compiler/linker flags from shared.cmake

Resolves: #477