### PR TITLE
operators: Add ref_count(other) operator overload.

### DIFF
--- a/Rx/v2/examples/doxygen/publish.cpp
+++ b/Rx/v2/examples/doxygen/publish.cpp
@@ -3,6 +3,9 @@
 #include "rxcpp/rx-test.hpp"
 #include "catch.hpp"
 
+#include <atomic>
+#include <array>
+
 SCENARIO("publish_synchronized sample"){
     printf("//! [publish_synchronized sample]\n");
     auto values = rxcpp::observable<>::interval(std::chrono::milliseconds(50)).
@@ -95,3 +98,95 @@ SCENARIO("publish behavior sample"){
     values.as_blocking().subscribe();
     printf("//! [publish behavior sample]\n");
 }
+
+SCENARIO("publish diamond bgthread sample"){
+    printf("//! [publish diamond bgthread sample]\n");
+
+    /*
+     * Implements the following diamond graph chain with publish+connect on a background thread.
+     *
+     *            Values
+     *          /      \
+     *        *2        *100
+     *          \      /
+     *            Merge
+     */
+    auto values = rxcpp::observable<>::interval(std::chrono::milliseconds(50), rxcpp::observe_on_new_thread()).
+        take(5).
+        publish();
+
+    // Left side multiplies by 2.
+    auto left = values.map(
+        [](long v){printf("[1] OnNext: %ld -> %ld\n", v, v*2); return v * 2;} );
+
+    // Right side multiplies by 100.
+    auto right = values.map(
+        [](long v){printf("[2] OnNext: %ld -> %ld\n", v, v*100); return v * 100; });
+
+    // Merge the left,right sides together.
+    // The items are emitted interleaved ... [left1, right1, left2, right2, left3, right3, ...].
+    auto merged = left.merge(right);
+
+    std::atomic<bool> completed{false};
+
+    // Add subscription to see results
+    merged.subscribe(
+        [](long v) { printf("[3] OnNext: %ld\n", v); },
+        [&]() { printf("[3] OnCompleted:\n"); completed = true; });
+
+    // Start emitting
+    values.connect();
+
+    // Block until subscription terminates.
+    while (!completed) {}
+
+    // Note: consider using ref_count(other) in real code, it's more composable.
+
+    printf("//! [publish diamond bgthread sample]\n");
+}
+
+SCENARIO("publish diamond samethread sample"){
+    printf("//! [publish diamond samethread sample]\n");
+
+    /*
+     * Implements the following diamond graph chain with publish+connect diamond without using threads.
+     *
+     *            Values
+     *          /      \
+     *        *2        *100
+     *          \      /
+     *            Merge
+     */
+
+    std::array<int, 5> a={{1, 2, 3, 4, 5}};
+    auto values = rxcpp::observable<>::iterate(a).
+        publish();
+
+    // Left side multiplies by 2.
+    auto left = values.map(
+        [](long v){printf("[1] OnNext: %ld -> %ld\n", v, v*2); return v * 2;} );
+
+    // Right side multiplies by 100.
+    auto right = values.map(
+        [](long v){printf("[2] OnNext: %ld -> %ld\n", v, v*100); return v * 100; });
+
+    // Merge the left,right sides together.
+    // The items are emitted interleaved ... [left1, right1, left2, right2, left3, right3, ...].
+    auto merged = left.merge(right);
+
+    // Add subscription to see results
+    merged.subscribe(
+        [](long v) { printf("[3] OnNext: %ld\n", v); },
+        [&]() { printf("[3] OnCompleted:\n"); });
+
+    // Start emitting
+    // - because there are no other threads here, the connect call blocks until the source
+    //   calls on_completed.
+    values.connect();
+
+    // Note: consider using ref_count(other) in real code, it's more composable.
+
+    printf("//! [publish diamond samethread sample]\n");
+}
+
+// see also examples/doxygen/ref_count.cpp for more diamond examples

--- a/Rx/v2/examples/doxygen/ref_count.cpp
+++ b/Rx/v2/examples/doxygen/ref_count.cpp
@@ -1,0 +1,55 @@
+#include "rxcpp/rx.hpp"
+
+#include "rxcpp/rx-test.hpp"
+#include "catch.hpp"
+
+#include <array>
+
+SCENARIO("ref_count other diamond sample"){
+    printf("//! [ref_count other diamond sample]\n");
+
+    /*
+     * Implements the following diamond graph chain with publish+ref_count without using threads.
+     * This version is composable because it does not use connect explicitly.
+     *
+     *            Values
+     *          /      \
+     *        *2        *100
+     *          \      /
+     *            Merge
+     *             |
+     *            RefCount
+     */
+
+    std::array<double, 5> a={{1.0, 2.0, 3.0, 4.0, 5.0}};
+    auto values = rxcpp::observable<>::iterate(a)
+        // The root of the chain is only subscribed to once.
+        .tap([](double v) { printf("[0] OnNext: %lf\n", v); })
+        .publish();
+
+    auto values_to_long = values.map([](double v) { return (long) v; });
+
+    // Left side multiplies by 2.
+    auto left = values_to_long.map(
+        [](long v) -> long {printf("[1] OnNext: %ld -> %ld\n", v, v*2); return v * 2L;} );
+
+    // Right side multiplies by 100.
+    auto right = values_to_long.map(
+        [](long v) -> long {printf("[2] OnNext: %ld -> %ld\n", v, v*100); return v * 100L; });
+
+    // Merge the left,right sides together.
+    // The items are emitted interleaved ... [left1, right1, left2, right2, left3, right3, ...].
+    auto merged = left.merge(right);
+
+    // When this value is subscribed to, it calls connect on values.
+    auto connect_on_subscribe = merged.ref_count(values);
+
+    // This immediately starts emitting all values and blocks until they are completed.
+    connect_on_subscribe.subscribe(
+        [](long v) { printf("[3] OnNext: %ld\n", v); },
+        [&]() { printf("[3] OnCompleted:\n"); });
+
+    printf("//! [ref_count other diamond sample]\n");
+}
+
+// see also examples/doxygen/publish.cpp for non-ref_count diamonds

--- a/Rx/v2/src/rxcpp/operators/rx-publish.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-publish.hpp
@@ -21,6 +21,18 @@
     \sample
     \snippet publish.cpp publish behavior sample
     \snippet output.txt publish behavior sample
+
+    \sample
+    \snippet publish.cpp publish diamond samethread sample
+    \snippet output.txt publish diamond samethread sample
+
+    \sample
+    \snippet publish.cpp publish diamond bgthread sample
+    \snippet output.txt publish diamond bgthread sample
+
+    \sample
+    \snippet ref_count.cpp ref_count other diamond sample
+    \snippet output.txt ref_count other diamond sample
 */
 
 #if !defined(RXCPP_OPERATORS_RX_PUBLISH_HPP)

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -574,6 +574,17 @@ public:
         static_assert(sizeof...(AN) == 0, "as_dynamic() was passed too many arguments.");
     }
 
+    /*! @copydoc rx-ref_count.hpp
+     */
+    template<class... AN>
+    auto ref_count(AN... an) const // ref_count(ConnectableObservable&&)
+        /// \cond SHOW_SERVICE_MEMBERS
+        -> decltype(observable_member(ref_count_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        /// \endcond
+    {
+        return      observable_member(ref_count_tag{},                *this, std::forward<AN>(an)...);
+    }
+
     /*! @copydoc rxcpp::operators::as_blocking
      */
     template<class... AN>

--- a/projects/doxygen/CMakeLists.txt
+++ b/projects/doxygen/CMakeLists.txt
@@ -84,6 +84,7 @@ if(DOXYGEN_FOUND)
         ${DOXY_EXAMPLES_SRC_DIR}/publish.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/range.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/reduce.cpp
+        ${DOXY_EXAMPLES_SRC_DIR}/ref_count.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/repeat.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/replay.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/retry.cpp


### PR DESCRIPTION
The existing `connectable_observable.ref_count()` operator calls
connect on the source when it's subscribed to.

Generalize this by allowing an optional parameter `other`, i.e.
`observable.ref_count(connectable_observable other)` to be used as the
connect target.

Useful for implementing diamond graphs while retaining composability:

```
     A
   /   \
  B     C
   \   /
     D
     |
     E

auto A = ... | publish();
auto B = A | ...;
auto C = A | ...;
auto D = B | merge(C) | ref_count(A);
auto E = D | ...;

E | subscribe(...);
```

Resolves: https://github.com/ReactiveX/RxCpp/issues/484