### PR TITLE
Fix data race in run loop usage

### DIFF
--- a/Rx/v2/src/rxcpp/schedulers/rx-runloop.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-runloop.hpp
@@ -164,10 +164,12 @@ public:
     }
     
     bool empty() const {
+        std::unique_lock<std::mutex> guard(state->lock);
         return state->q.empty();
     }
 
     const_reference_item_type peek() const {
+        std::unique_lock<std::mutex> guard(state->lock);
         return state->q.top();
     }
 


### PR DESCRIPTION
Thread sanitizer detects a data race in this run loop usage example https://github.com/ReactiveX/RxCpp/pull/154 
https://gist.github.com/lebdron/ee3e3e74250c27b2595a732bae5a9a22
Since queue can be accessed both by current thread and some other thread which calls `schedule()`, queue handles have to be protected by a lock.