### PR TITLE
removed constexpr to support older VC compilers.

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-ref_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-ref_count.hpp
@@ -90,7 +90,8 @@ struct ref_count : public operator_base<T>
     // ref_count() == false
     // ref_count(other) == true
     using has_observable_t = rxu::negation<std::is_same<void, Observable>>;
-    static constexpr bool has_observable_v = has_observable_t::value;
+    // removed constexpr to support older VC compilers
+    static /*constexpr */ const bool has_observable_v = has_observable_t::value;
 
     struct ref_count_state : public std::enable_shared_from_this<ref_count_state>,
                              public ref_count_state_base<ConnectableObservable, Observable>


### PR DESCRIPTION
In VS2013.5, the following statement causes a compilation error. 
![Problem_2](https://user-images.githubusercontent.com/42833718/61195499-f5f4b280-a6fa-11e9-8538-e98a69924399.png)

Notice that the same compatibility is done here.
https://github.com/ReactiveX/RxCpp/blob/f38fb8e3c30b01b07c57e08039b2942f1685224d/Rx/v2/src/rxcpp/rx-util.hpp#L67-L72
