### PR TITLE
make find_package(rxcpp CONFIG) work through exporting TARGETS

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ git clone --recursive https://github.com/ReactiveX/RxCpp.git
 cd RxCpp
 ```
 
+# Installing
+
+To install RxCpp into your OS you need to follow standart procedure:
+```shell
+mkdir build
+cd build
+cmake ..
+make install 
+```
+
+# Importing
+
+After you have successfully installed RxCpp you can import it into any project by simply adding to your CMakeLists.txt:
+```cmake
+find_package(rxcpp CONFIG)
+``` 
+
 # Building RxCpp Unit Tests
 
 * RxCpp is regularly tested on OSX and Windows.

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -146,3 +146,27 @@ set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE CACHE BOOL "Don't require all project
 
 install(DIRECTORY ${RXCPP_DIR}/Rx/v2/src/rxcpp/ DESTINATION include/rxcpp
         FILES_MATCHING PATTERN "*.hpp")
+
+# Here we are exporting TARGETS so that other projects can import rxcpp
+# just with find_package(rxcpp CONFIG) after rxcpp is installed into system by "make install". 
+add_library(rxcpp INTERFACE)
+
+target_include_directories(rxcpp INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/rxcpp>
+)
+
+install(TARGETS rxcpp EXPORT rxcppConfig)
+install(EXPORT rxcppConfig DESTINATION share/rxcpp/cmake)
+
+# When find_package(rxcpp SOME_VERSION REQUIRED) will be used in third party project
+# where SOME_VERSION is any version incompatible with ${PROJECT_VERSION} then cmake will generate the error.
+# It means you don't need track versions manually.
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${PROJECT_BINARY_DIR}/rxcppConfigVersion.cmake"
+    VERSION
+        ${PROJECT_VERSION}
+    COMPATIBILITY
+        AnyNewerVersion
+)
+install(FILES "${PROJECT_BINARY_DIR}/rxcppConfigVersion.cmake" DESTINATION share/rxcpp/cmake)


### PR DESCRIPTION
Signed-off-by: exctues <alexnamecode@gmail.com>

The idea is to allow Config mode(not only Module) in find_package function.
So, now in order to import rxcpp in the other project what you need to do is:
1) install rxcpp by "make install"
2) add find_package(rxcpp CONFIG) into CMakeLists.txt