### PR TITLE
Observable forward declaration header

### DIFF
--- a/Rx/v2/src/rxcpp/rx-observable-fwd.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable-fwd.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+#pragma once
+
+#if !defined(RXCPP_RX_OBSERVABLE_FWD_HPP)
+#define RXCPP_RX_OBSERVABLE_FWD_HPP
+
+#include <type_traits>
+
+namespace rxcpp {
+
+template<class T>
+class dynamic_observable;
+
+template<
+    class T = void,
+    class SourceObservable = typename std::conditional<std::is_same<T, void>::value,
+        void, dynamic_observable<T>>::type>
+class observable;
+
+template<class T, class Source>
+observable<T> make_observable_dynamic(Source&&);
+
+}
+
+#endif

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -458,7 +458,7 @@ struct take_until_tag {
 struct tap_tag {
     template<class Included>
     struct include_header{
-        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-rap.hpp>");
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-tap.hpp>");
     };
 };
 

--- a/Rx/v2/src/rxcpp/rx-predef.hpp
+++ b/Rx/v2/src/rxcpp/rx-predef.hpp
@@ -6,6 +6,7 @@
 #define RXCPP_RX_PREDEF_HPP
 
 #include "rx-includes.hpp"
+#include "rx-observable-fwd.hpp"
 
 namespace rxcpp {
 
@@ -135,18 +136,6 @@ class is_dynamic_observable
 public:
     static const bool value = std::is_convertible<decltype(check<rxu::decay_t<T>>(0)), tag_dynamic_observable*>::value;
 };
-
-template<class T>
-class dynamic_observable;
-
-template<
-    class T = void,
-    class SourceObservable = typename std::conditional<std::is_same<T, void>::value,
-        void, dynamic_observable<T>>::type>
-class observable;
-
-template<class T, class Source>
-observable<T> make_observable_dynamic(Source&&);
 
 template<class Selector, class Default, template<class... TN> class SO, class... AN>
 struct defer_observable;


### PR DESCRIPTION
Using https://github.com/aras-p/ClangBuildAnalyzer allowed us to check that including `rxcpp/rx.h` was taking significant part of build time. It was possible to reduce it by using `rx-lite`, but the forward declaring header allowed to reduce it even more, because `observable` is used in interfaces.