### PR TITLE
Add throttle operator

### DIFF
--- a/Rx/v2/examples/doxygen/throttle.cpp
+++ b/Rx/v2/examples/doxygen/throttle.cpp
@@ -1,0 +1,20 @@
+#include "rxcpp/rx.hpp"
+
+#include "rxcpp/rx-test.hpp"
+#include "catch.hpp"
+
+SCENARIO("throttle sample"){
+    printf("//! [throttle sample]\n");
+    using namespace std::chrono;
+    auto scheduler = rxcpp::identity_current_thread();
+    auto start = scheduler.now();
+    auto period = milliseconds(10);
+    auto values = rxcpp::observable<>::interval(start, period, scheduler).
+        take(4).
+        throttle(period);
+    values.
+        subscribe(
+            [](long v) { printf("OnNext: %ld\n", v); },
+            []() { printf("OnCompleted\n"); });
+    printf("//! [throttle sample]\n");
+}

--- a/Rx/v2/src/rxcpp/operators/rx-throttle.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-throttle.hpp
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+#pragma once
+
+/*! \file rx-throttle.hpp
+
+    \brief  Return an observable that emits a value from the source and then ignores any following items until a particular timespan has passed before emitting another value.
+
+    \tparam Duration      the type of the time interval
+    \tparam Coordination  the type of the scheduler
+
+    \param period        the period of time to suppress any emitted items after the first emission
+    \param coordination  the scheduler to manage timeout for each event
+
+    \return  Observable that emits a value from the source and then ignores any following items until a particular timespan has passed before emitting another value.
+
+    \sample
+    \snippet throttle.cpp throttle sample
+    \snippet output.txt throttle sample
+*/
+
+#if !defined(RXCPP_OPERATORS_RX_THROTTLE_HPP)
+#define RXCPP_OPERATORS_RX_THROTTLE_HPP
+
+#include "../rx-includes.hpp"
+
+#include <iostream>
+
+namespace rxcpp {
+
+namespace operators {
+
+namespace detail {
+
+template<class... AN>
+struct throttle_invalid_arguments {};
+
+template<class... AN>
+struct throttle_invalid : public rxo::operator_base<throttle_invalid_arguments<AN...>> {
+    using type = observable<throttle_invalid_arguments<AN...>, throttle_invalid<AN...>>;
+};
+template<class... AN>
+using throttle_invalid_t = typename throttle_invalid<AN...>::type;
+
+template<class T, class Duration, class Coordination>
+struct throttle
+{
+    typedef rxu::decay_t<T> source_value_type;
+    typedef rxu::decay_t<Coordination> coordination_type;
+    typedef typename coordination_type::coordinator_type coordinator_type;
+    typedef rxu::decay_t<Duration> duration_type;
+
+    struct throttle_values
+    {
+        throttle_values(duration_type p, coordination_type c)
+            : period(p)
+            , coordination(c)
+        {
+        }
+
+        duration_type period;
+        coordination_type coordination;
+    };
+    throttle_values initial;
+
+    throttle(duration_type period, coordination_type coordination)
+        : initial(period, coordination)
+    {
+    }
+
+    template<class Subscriber>
+    struct throttle_observer
+    {
+        typedef throttle_observer<Subscriber> this_type;
+        typedef rxu::decay_t<T> value_type;
+        typedef rxu::decay_t<Subscriber> dest_type;
+        typedef observer<T, this_type> observer_type;
+
+        struct throttle_subscriber_values : public throttle_values
+        {
+            throttle_subscriber_values(composite_subscription cs, dest_type d, throttle_values v, coordinator_type c)
+                : throttle_values(v)
+                , cs(std::move(cs))
+                , dest(std::move(d))
+                , coordinator(std::move(c))
+                , worker(coordinator.get_worker())
+                , throttled(false)
+            {
+            }
+
+            composite_subscription cs;
+            dest_type dest;
+            coordinator_type coordinator;
+            rxsc::worker worker;
+            mutable bool throttled;
+        };
+        typedef std::shared_ptr<throttle_subscriber_values> state_type;
+        state_type state;
+
+        throttle_observer(composite_subscription cs, dest_type d, throttle_values v, coordinator_type c)
+            : state(std::make_shared<throttle_subscriber_values>(throttle_subscriber_values(std::move(cs), std::move(d), v, std::move(c))))
+        {
+            auto localState = state;
+
+            auto disposer = [=](const rxsc::schedulable&){
+                localState->cs.unsubscribe();
+                localState->dest.unsubscribe();
+                localState->worker.unsubscribe();
+            };
+            auto selectedDisposer = on_exception(
+                [&](){ return localState->coordinator.act(disposer); },
+                localState->dest);
+            if (selectedDisposer.empty()) {
+                return;
+            }
+
+            localState->dest.add([=](){
+                localState->worker.schedule(selectedDisposer.get());
+            });
+            localState->cs.add([=](){
+                localState->worker.schedule(selectedDisposer.get());
+            });
+        }
+
+        static std::function<void(const rxsc::schedulable&)> reset_throttle(state_type state) {
+            auto reset = [state](const rxsc::schedulable&) {
+                state->throttled = false;
+            };
+
+            auto selectedReset = on_exception(
+                    [&](){ return state->coordinator.act(reset); },
+                    state->dest);
+            if (selectedReset.empty()) {
+                return std::function<void(const rxsc::schedulable&)>();
+            }
+
+            return std::function<void(const rxsc::schedulable&)>(selectedReset.get());
+        }
+
+        void on_next(T v) const {
+            auto localState = state;
+
+            const auto tp = localState->worker.now().time_since_epoch();
+            std::cout << "on_next(" << v << ") at " << tp.count() / 1000000 << " throttled: " << (localState->throttled ? "true" : "false") << std::endl;
+
+            if (!localState->throttled) {
+                localState->throttled = true;
+
+                state->dest.on_next(v);
+
+                auto work = [v, localState](const rxsc::schedulable&) {
+                    auto produce_time = localState->worker.now() + localState->period;
+
+                    std::cout << "scheduling unthrottle for " << (produce_time.time_since_epoch().count() / 1000000) << std::endl;
+
+                    localState->worker.schedule(produce_time, reset_throttle(localState));
+                };
+                auto selectedWork = on_exception(
+                    [&](){return localState->coordinator.act(work);},
+                    localState->dest);
+                if (selectedWork.empty()) {
+                    return;
+                }
+                localState->worker.schedule(selectedWork.get());
+            }
+        }
+
+        void on_error(rxu::error_ptr e) const {
+            auto localState = state;
+            auto work = [e, localState](const rxsc::schedulable&) {
+                localState->dest.on_error(e);
+            };
+            auto selectedWork = on_exception(
+                [&](){ return localState->coordinator.act(work); },
+                localState->dest);
+            if (selectedWork.empty()) {
+                return;
+            }
+            localState->worker.schedule(selectedWork.get());
+        }
+
+        void on_completed() const {
+            auto localState = state;
+            auto work = [localState](const rxsc::schedulable&) {
+                localState->dest.on_completed();
+            };
+            auto selectedWork = on_exception(
+                [&](){ return localState->coordinator.act(work); },
+                localState->dest);
+            if (selectedWork.empty()) {
+                return;
+            }
+            localState->worker.schedule(selectedWork.get());
+        }
+
+        static subscriber<T, observer_type> make(dest_type d, throttle_values v) {
+            auto cs = composite_subscription();
+            auto coordinator = v.coordination.create_coordinator();
+
+            return make_subscriber<T>(cs, observer_type(this_type(cs, std::move(d), std::move(v), std::move(coordinator))));
+        }
+    };
+
+    template<class Subscriber>
+    auto operator()(Subscriber dest) const
+        -> decltype(throttle_observer<Subscriber>::make(std::move(dest), initial)) {
+        return      throttle_observer<Subscriber>::make(std::move(dest), initial);
+    }
+};
+
+}
+
+/*! @copydoc rx-throttle.hpp
+*/
+template<class... AN>
+auto throttle(AN&&... an)
+    ->      operator_factory<throttle_tag, AN...> {
+     return operator_factory<throttle_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
+}
+
+}
+
+template<>
+struct member_overload<throttle_tag>
+{
+    template<class Observable, class Duration,
+        class Enabled = rxu::enable_if_all_true_type_t<
+            is_observable<Observable>,
+            rxu::is_duration<Duration>>,
+        class SourceValue = rxu::value_type_t<Observable>,
+        class Throttle = rxo::detail::throttle<SourceValue, rxu::decay_t<Duration>, identity_one_worker>>
+    static auto member(Observable&& o, Duration&& d)
+        -> decltype(o.template lift<SourceValue>(Throttle(std::forward<Duration>(d), identity_current_thread()))) {
+        return      o.template lift<SourceValue>(Throttle(std::forward<Duration>(d), identity_current_thread()));
+    }
+
+    template<class Observable, class Coordination, class Duration,
+        class Enabled = rxu::enable_if_all_true_type_t<
+            is_observable<Observable>,
+            is_coordination<Coordination>,
+            rxu::is_duration<Duration>>,
+        class SourceValue = rxu::value_type_t<Observable>,
+        class Throttle = rxo::detail::throttle<SourceValue, rxu::decay_t<Duration>, rxu::decay_t<Coordination>>>
+    static auto member(Observable&& o, Coordination&& cn, Duration&& d)
+        -> decltype(o.template lift<SourceValue>(Throttle(std::forward<Duration>(d), std::forward<Coordination>(cn)))) {
+        return      o.template lift<SourceValue>(Throttle(std::forward<Duration>(d), std::forward<Coordination>(cn)));
+    }
+
+    template<class Observable, class Coordination, class Duration,
+        class Enabled = rxu::enable_if_all_true_type_t<
+            is_observable<Observable>,
+            is_coordination<Coordination>,
+            rxu::is_duration<Duration>>,
+        class SourceValue = rxu::value_type_t<Observable>,
+        class Throttle = rxo::detail::throttle<SourceValue, rxu::decay_t<Duration>, rxu::decay_t<Coordination>>>
+    static auto member(Observable&& o, Duration&& d, Coordination&& cn)
+        -> decltype(o.template lift<SourceValue>(Throttle(std::forward<Duration>(d), std::forward<Coordination>(cn)))) {
+        return      o.template lift<SourceValue>(Throttle(std::forward<Duration>(d), std::forward<Coordination>(cn)));
+    }
+
+    template<class... AN>
+    static operators::detail::throttle_invalid_t<AN...> member(const AN&...) {
+        std::terminate();
+        return {};
+        static_assert(sizeof...(AN) == 10000, "throttle takes (optional Coordination, required Duration) or (required Duration, optional Coordination)");
+    }
+};
+
+}
+
+#endif

--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -259,6 +259,7 @@
 #include "operators/rx-take_until.hpp"
 #include "operators/rx-take_while.hpp"
 #include "operators/rx-tap.hpp"
+#include "operators/rx-throttle.hpp"
 #include "operators/rx-time_interval.hpp"
 #include "operators/rx-timeout.hpp"
 #include "operators/rx-timestamp.hpp"

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -1417,6 +1417,17 @@ public:
         return      observable_member(take_while_tag{},                *this, std::forward<AN>(an)...);
     }
 
+    /*! @copydoc rx-throttle.hpp
+     */
+    template<class... AN>
+    auto throttle(AN&&... an) const
+        /// \cond SHOW_SERVICE_MEMBERS
+        -> decltype(observable_member(throttle_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        /// \endcond
+    {
+        return  observable_member(throttle_tag{},                *this, std::forward<AN>(an)...);
+    }
+
     /*! @copydoc rx-repeat.hpp
      */
     template<class... AN>

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -462,6 +462,13 @@ struct tap_tag {
     };
 };
 
+struct throttle_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-throttle.hpp>");
+    };
+};
+
 struct timeout_tag {
     template<class Included>
     struct include_header{

--- a/Rx/v2/test/CMakeLists.txt
+++ b/Rx/v2/test/CMakeLists.txt
@@ -79,6 +79,7 @@ set(TEST_SOURCES
     ${TEST_DIR}/operators/take_until.cpp
     ${TEST_DIR}/operators/take_while.cpp
     ${TEST_DIR}/operators/tap.cpp
+    ${TEST_DIR}/operators/throttle.cpp
     ${TEST_DIR}/operators/time_interval.cpp
     ${TEST_DIR}/operators/timeout.cpp
     ${TEST_DIR}/operators/timestamp.cpp

--- a/Rx/v2/test/operators/throttle.cpp
+++ b/Rx/v2/test/operators/throttle.cpp
@@ -1,0 +1,216 @@
+#include "../test.h"
+#include <rxcpp/operators/rx-throttle.hpp>
+
+using namespace std::chrono;
+
+SCENARIO("throttle - never", "[throttle][operators]"){
+    GIVEN("a source"){
+        auto sc = rxsc::make_test();
+        auto so = rx::synchronize_in_one_worker(sc);
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1)
+        });
+
+        WHEN("values are throttled"){
+
+            auto res = w.start(
+                [so, xs]() {
+                    return xs | rxo::throttle(so, milliseconds(10));
+                }
+            );
+
+            THEN("the output is empty"){
+                auto required = std::vector<rxsc::test::messages<int>::recorded_type>();
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 1001)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("throttle - empty", "[throttle][operators]"){
+    GIVEN("a source"){
+        auto sc = rxsc::make_test();
+        auto so = rx::synchronize_in_one_worker(sc);
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.completed(250)
+        });
+
+        WHEN("values are throttled"){
+
+            auto res = w.start(
+                [so, xs]() {
+                    return xs.throttle(milliseconds(10), so);
+                }
+            );
+
+            THEN("the output only contains complete message"){
+                auto required = rxu::to_vector({
+                    on.completed(251)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
+SCENARIO("throttle - no overlap", "[throttle][operators]"){
+    GIVEN("a source"){
+        auto sc = rxsc::make_test();
+        auto so = rx::synchronize_in_one_worker(sc);
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(240, 3),
+            on.completed(300)
+        });
+
+        WHEN("values are throtteled"){
+
+            auto res = w.start(
+                [so, xs]() {
+                    return xs.throttle(milliseconds(10), so);
+                }
+            );
+
+            THEN("the output only contains throttled items sent while subscribed"){
+                auto required = rxu::to_vector({
+                    on.next(210, 2),
+                    on.next(240, 3),
+                    on.completed(301)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 300)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
+SCENARIO("throttle - overlap", "[throttle][operators]"){
+    GIVEN("a source"){
+        auto sc = rxsc::make_test();
+        auto so = rx::synchronize_in_one_worker(sc);
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(215, 2),
+            on.next(225, 3),
+            on.next(235, 4),
+            on.next(247, 5),
+            on.next(255, 6),
+            on.next(265, 7),
+            on.next(500, 8),
+            on.completed(600)
+        });
+
+        WHEN("values are throttled"){
+
+            auto res = w.start(
+                [so, xs]() {
+                    return xs.throttle(milliseconds(30), so);
+                }
+            );
+
+            THEN("the output only contains throttled items sent while subscribed"){
+                auto required = rxu::to_vector({
+                    on.next(215, 2),
+                    on.next(247, 5),
+                    on.next(500, 8),
+                    on.completed(601)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 600)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
+SCENARIO("throttle - throw", "[throttle][operators]"){
+    GIVEN("a source"){
+        auto sc = rxsc::make_test();
+        auto so = rx::synchronize_in_one_worker(sc);
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        std::runtime_error ex("throttle on_error from source");
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.error(250, ex)
+        });
+
+        WHEN("values are throttled"){
+
+            auto res = w.start(
+                [so, xs]() {
+                    return xs.throttle(milliseconds(10), so);
+                }
+            );
+
+            THEN("the output only contains only error"){
+                auto required = rxu::to_vector({
+                    on.error(251, ex)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}

--- a/projects/doxygen/CMakeLists.txt
+++ b/projects/doxygen/CMakeLists.txt
@@ -106,6 +106,7 @@ if(DOXYGEN_FOUND)
         ${DOXY_EXAMPLES_SRC_DIR}/take_until.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/take_while.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/tap.cpp
+        ${DOXY_EXAMPLES_SRC_DIR}/throttle.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/time_interval.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/timeout.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/timer.cpp


### PR DESCRIPTION
I'm used to RxJS and loved the concept, so I wanted to use it in C++ as well. Seeing #501, I thought this would be a good opportunity for me to get a little deeper into understanding the implementation of RxCpp.

This is mostly a copy&paste of the `debounce` operator implementation, edited to implement `throttle` semantics ([ref. RxJS](https://rxjs-dev.firebaseapp.com/api/operators/throttleTime)).

The `throttle` operator re-emits the first value emitted by the source, then swallows all following emissions until the specified timeout has occurred. After that, the next value emitted by the source is emitted again and the cycle continues.

The RxJS implementation also supports emitting the last value emitted by the source when the timeout completes. If this is a feature you would like to see, I can add support for that as well.