### PR TITLE
Fixed build interface include directories for CMake projects

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -152,7 +152,7 @@ install(DIRECTORY ${RXCPP_DIR}/Rx/v2/src/rxcpp/ DESTINATION include/rxcpp
 add_library(rxcpp INTERFACE)
 
 target_include_directories(rxcpp INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${RXCPP_DIR}/Rx/v2/src/>
     $<INSTALL_INTERFACE:include/rxcpp>
 )
 


### PR DESCRIPTION
Hi all,

I am using RxCpp in my CMake project, having it added as a git submodule and connected to my project via cmake 'add_subdirectory'. I had initial problems as it seems that the cmake BUILD_INTERFACE was pointing to the non-existent folder 'projects/CMake/include', and was a quick fix to point it to the proper location.

Thnx :smile: 