### PR TITLE
Fix std::result_of removed in C++20

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
@@ -295,13 +295,13 @@ struct member_overload<concat_map_tag>
     template<class Observable, class CollectionSelector,
         class CollectionSelectorType = rxu::decay_t<CollectionSelector>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class CollectionType = rxu::result_of_t<CollectionSelectorType(SourceValue)>,
+        class CollectionType = rxu::invoke_result_t<CollectionSelectorType, SourceValue>,
         class ResultSelectorType = rxu::detail::take_at<1>,
         class Enabled = rxu::enable_if_all_true_type_t<
             all_observables<Observable, CollectionType>>,
         class ConcatMap = rxo::detail::concat_map<rxu::decay_t<Observable>, rxu::decay_t<CollectionSelector>, ResultSelectorType, identity_one_worker>,
         class CollectionValueType = rxu::value_type_t<CollectionType>,
-        class Value = rxu::result_of_t<ResultSelectorType(SourceValue, CollectionValueType)>,
+        class Value = rxu::invoke_result_t<ResultSelectorType, SourceValue, CollectionValueType>,
         class Result = observable<Value, ConcatMap>
     >
     static Result member(Observable&& o, CollectionSelector&& s) {
@@ -311,14 +311,14 @@ struct member_overload<concat_map_tag>
     template<class Observable, class CollectionSelector, class Coordination,
         class CollectionSelectorType = rxu::decay_t<CollectionSelector>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class CollectionType = rxu::result_of_t<CollectionSelectorType(SourceValue)>,
+        class CollectionType = rxu::invoke_result_t<CollectionSelectorType, SourceValue>,
         class ResultSelectorType = rxu::detail::take_at<1>,
         class Enabled = rxu::enable_if_all_true_type_t<
             all_observables<Observable, CollectionType>,
             is_coordination<Coordination>>,
         class ConcatMap = rxo::detail::concat_map<rxu::decay_t<Observable>, rxu::decay_t<CollectionSelector>, ResultSelectorType, rxu::decay_t<Coordination>>,
         class CollectionValueType = rxu::value_type_t<CollectionType>,
-        class Value = rxu::result_of_t<ResultSelectorType(SourceValue, CollectionValueType)>,
+        class Value = rxu::invoke_result_t<ResultSelectorType, SourceValue, CollectionValueType>,
         class Result = observable<Value, ConcatMap>
     >
     static Result member(Observable&& o, CollectionSelector&& s, Coordination&& cn) {
@@ -329,14 +329,14 @@ struct member_overload<concat_map_tag>
         class IsCoordination = is_coordination<ResultSelector>,
         class CollectionSelectorType = rxu::decay_t<CollectionSelector>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class CollectionType = rxu::result_of_t<CollectionSelectorType(SourceValue)>,
+        class CollectionType = rxu::invoke_result_t<CollectionSelectorType, SourceValue>,
         class Enabled = rxu::enable_if_all_true_type_t<
             all_observables<Observable, CollectionType>,
             rxu::negation<IsCoordination>>,
         class ConcatMap = rxo::detail::concat_map<rxu::decay_t<Observable>, rxu::decay_t<CollectionSelector>, rxu::decay_t<ResultSelector>, identity_one_worker>,
         class CollectionValueType = rxu::value_type_t<CollectionType>,
         class ResultSelectorType = rxu::decay_t<ResultSelector>,
-        class Value = rxu::result_of_t<ResultSelectorType(SourceValue, CollectionValueType)>,
+        class Value = rxu::invoke_result_t<ResultSelectorType, SourceValue, CollectionValueType>,
         class Result = observable<Value, ConcatMap>
     >
     static Result member(Observable&& o, CollectionSelector&& s, ResultSelector&& rs) {
@@ -346,14 +346,14 @@ struct member_overload<concat_map_tag>
     template<class Observable, class CollectionSelector, class ResultSelector, class Coordination,
         class CollectionSelectorType = rxu::decay_t<CollectionSelector>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class CollectionType = rxu::result_of_t<CollectionSelectorType(SourceValue)>,
+        class CollectionType = rxu::invoke_result_t<CollectionSelectorType, SourceValue>,
         class Enabled = rxu::enable_if_all_true_type_t<
             all_observables<Observable, CollectionType>,
             is_coordination<Coordination>>,
         class ConcatMap = rxo::detail::concat_map<rxu::decay_t<Observable>, rxu::decay_t<CollectionSelector>, rxu::decay_t<ResultSelector>, rxu::decay_t<Coordination>>,
         class CollectionValueType = rxu::value_type_t<CollectionType>,
         class ResultSelectorType = rxu::decay_t<ResultSelector>,
-        class Value = rxu::result_of_t<ResultSelectorType(SourceValue, CollectionValueType)>,
+        class Value = rxu::invoke_result_t<ResultSelectorType, SourceValue, CollectionValueType>,
         class Result = observable<Value, ConcatMap>
     >
     static Result member(Observable&& o, CollectionSelector&& s, ResultSelector&& rs, Coordination&& cn) {

--- a/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
@@ -262,13 +262,13 @@ struct member_overload<flat_map_tag>
     template<class Observable, class CollectionSelector,
         class CollectionSelectorType = rxu::decay_t<CollectionSelector>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class CollectionType = rxu::result_of_t<CollectionSelectorType(SourceValue)>,
+        class CollectionType = rxu::invoke_result_t<CollectionSelectorType, SourceValue>,
         class ResultSelectorType = rxu::detail::take_at<1>,
         class Enabled = rxu::enable_if_all_true_type_t<
             all_observables<Observable, CollectionType>>,
         class FlatMap = rxo::detail::flat_map<rxu::decay_t<Observable>, rxu::decay_t<CollectionSelector>, ResultSelectorType, identity_one_worker>,
         class CollectionValueType = rxu::value_type_t<CollectionType>,
-        class Value = rxu::result_of_t<ResultSelectorType(SourceValue, CollectionValueType)>,
+        class Value = rxu::invoke_result_t<ResultSelectorType, SourceValue, CollectionValueType>,
         class Result = observable<Value, FlatMap>
     >
     static Result member(Observable&& o, CollectionSelector&& s) {
@@ -278,14 +278,14 @@ struct member_overload<flat_map_tag>
     template<class Observable, class CollectionSelector, class Coordination,
         class CollectionSelectorType = rxu::decay_t<CollectionSelector>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class CollectionType = rxu::result_of_t<CollectionSelectorType(SourceValue)>,
+        class CollectionType = rxu::invoke_result_t<CollectionSelectorType, SourceValue>,
         class ResultSelectorType = rxu::detail::take_at<1>,
         class Enabled = rxu::enable_if_all_true_type_t<
             all_observables<Observable, CollectionType>,
             is_coordination<Coordination>>,
         class FlatMap = rxo::detail::flat_map<rxu::decay_t<Observable>, rxu::decay_t<CollectionSelector>, ResultSelectorType, rxu::decay_t<Coordination>>,
         class CollectionValueType = rxu::value_type_t<CollectionType>,
-        class Value = rxu::result_of_t<ResultSelectorType(SourceValue, CollectionValueType)>,
+        class Value = rxu::invoke_result_t<ResultSelectorType, SourceValue, CollectionValueType>,
         class Result = observable<Value, FlatMap>
     >
     static Result member(Observable&& o, CollectionSelector&& s, Coordination&& cn) {
@@ -296,14 +296,14 @@ struct member_overload<flat_map_tag>
         class IsCoordination = is_coordination<ResultSelector>,
         class CollectionSelectorType = rxu::decay_t<CollectionSelector>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class CollectionType = rxu::result_of_t<CollectionSelectorType(SourceValue)>,
+        class CollectionType = rxu::invoke_result_t<CollectionSelectorType, SourceValue>,
         class Enabled = rxu::enable_if_all_true_type_t<
             all_observables<Observable, CollectionType>,
             rxu::negation<IsCoordination>>,
         class FlatMap = rxo::detail::flat_map<rxu::decay_t<Observable>, rxu::decay_t<CollectionSelector>, rxu::decay_t<ResultSelector>, identity_one_worker>,
         class CollectionValueType = rxu::value_type_t<CollectionType>,
         class ResultSelectorType = rxu::decay_t<ResultSelector>,
-        class Value = rxu::result_of_t<ResultSelectorType(SourceValue, CollectionValueType)>,
+        class Value = rxu::invoke_result_t<ResultSelectorType, SourceValue, CollectionValueType>,
         class Result = observable<Value, FlatMap>
     >
     static Result member(Observable&& o, CollectionSelector&& s, ResultSelector&& rs) {
@@ -313,14 +313,14 @@ struct member_overload<flat_map_tag>
     template<class Observable, class CollectionSelector, class ResultSelector, class Coordination,
         class CollectionSelectorType = rxu::decay_t<CollectionSelector>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class CollectionType = rxu::result_of_t<CollectionSelectorType(SourceValue)>,
+        class CollectionType = rxu::invoke_result_t<CollectionSelectorType, SourceValue>,
         class Enabled = rxu::enable_if_all_true_type_t<
             all_observables<Observable, CollectionType>,
             is_coordination<Coordination>>,
         class FlatMap = rxo::detail::flat_map<rxu::decay_t<Observable>, rxu::decay_t<CollectionSelector>, rxu::decay_t<ResultSelector>, rxu::decay_t<Coordination>>,
         class CollectionValueType = rxu::value_type_t<CollectionType>,
         class ResultSelectorType = rxu::decay_t<ResultSelector>,
-        class Value = rxu::result_of_t<ResultSelectorType(SourceValue, CollectionValueType)>,
+        class Value = rxu::invoke_result_t<ResultSelectorType, SourceValue, CollectionValueType>,
         class Result = observable<Value, FlatMap>
     >
     static Result member(Observable&& o, CollectionSelector&& s, ResultSelector&& rs, Coordination&& cn) {

--- a/Rx/v2/src/rxcpp/operators/rx-window_toggle.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_toggle.hpp
@@ -57,7 +57,7 @@ struct window_toggle
     using openings_type = rxu::decay_t<Openings>;
     using openings_value_type = typename openings_type::value_type;
     using closing_selector_type = rxu::decay_t<ClosingSelector>;
-    using closings_type = rxu::result_of_t<closing_selector_type(openings_value_type)>;
+    using closings_type = rxu::invoke_result_t<closing_selector_type, openings_value_type>;
     using closings_value_type = typename closings_type::value_type;
 
     struct window_toggle_values
@@ -287,7 +287,7 @@ struct member_overload<window_toggle_tag>
         class OpeningsType = rxu::decay_t<Openings>,
         class OpeningsValueType = typename OpeningsType::value_type,
         class Enabled = rxu::enable_if_all_true_type_t<
-            all_observables<Observable, Openings, rxu::result_of_t<ClosingSelectorType(OpeningsValueType)>>>,
+            all_observables<Observable, Openings, rxu::invoke_result_t<ClosingSelectorType, OpeningsValueType>>>,
         class SourceValue = rxu::value_type_t<Observable>,
         class WindowToggle = rxo::detail::window_toggle<SourceValue, rxu::decay_t<Openings>, rxu::decay_t<ClosingSelector>, identity_one_worker>,
         class Value = observable<SourceValue>>
@@ -301,7 +301,7 @@ struct member_overload<window_toggle_tag>
         class OpeningsType = rxu::decay_t<Openings>,
         class OpeningsValueType = typename OpeningsType::value_type,
         class Enabled = rxu::enable_if_all_true_type_t<
-            all_observables<Observable, Openings, rxu::result_of_t<ClosingSelectorType(OpeningsValueType)>>,
+            all_observables<Observable, Openings, rxu::invoke_result_t<ClosingSelectorType, OpeningsValueType>>,
             is_coordination<Coordination>>,
         class SourceValue = rxu::value_type_t<Observable>,
         class WindowToggle = rxo::detail::window_toggle<SourceValue, rxu::decay_t<Openings>, rxu::decay_t<ClosingSelector>, rxu::decay_t<Coordination>>,

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -46,7 +46,12 @@ namespace util {
 
 template<class T> using value_type_t = typename std::decay<T>::type::value_type;
 template<class T> using decay_t = typename std::decay<T>::type;
-template<class... TN> using result_of_t = typename std::result_of<TN...>::type;
+
+#if defined(__cpp_lib_is_invocable)
+template<class F, class... TN> using invoke_result_t = typename std::invoke_result<F, TN...>::type;
+#else
+template<class F, class... TN> using invoke_result_t = typename std::result_of<F(TN...)>::type;
+#endif
 
 template<class T, std::size_t size>
 std::vector<T> to_vector(const T (&arr) [size]) {
@@ -1013,7 +1018,7 @@ struct is_hashable<T,
     typename rxu::types_checked_from<
         typename filtered_hash<T>::result_type,
         typename filtered_hash<T>::argument_type,
-        typename std::result_of<filtered_hash<T>(T)>::type>::type>
+        typename rxu::invoke_result_t<filtered_hash<T>, T>>::type>
     : std::true_type {};
 
 }


### PR DESCRIPTION
Fix for #530 based on [comment](https://github.com/ReactiveX/RxCpp/issues/530#issuecomment-648896581) by @arolson101.

I used `__cpp_lib_is_invocable` feature test macro to detect the presence of `std::invoke_result`.