### PR TITLE
Included <string> in rx-includes.hpp 

### DIFF
--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -166,6 +166,8 @@
 
 #include <cstddef>
 
+#include <string>
+
 #include <iostream>
 #include <iomanip>
 


### PR DESCRIPTION
Included <string> in rx-includes.hpp to compile rxcpp on platform where <string>

is not included indirectly.