### PR TITLE
Fix std::result_of removed in C++20

### DIFF
--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -46,7 +46,19 @@ namespace util {
 
 template<class T> using value_type_t = typename std::decay<T>::type::value_type;
 template<class T> using decay_t = typename std::decay<T>::type;
+#ifdef __cpp_lib_is_invocable
+template <class> struct result_of;
+
+template <class F, class... TN>
+struct result_of<F(TN...)>
+{
+    using type = std::invoke_result_t<F, TN...>;
+};
+
+template<class... TN> using result_of_t = typename result_of<TN...>::type;
+#else
 template<class... TN> using result_of_t = typename std::result_of<TN...>::type;
+#endif
 
 template<class T, std::size_t size>
 std::vector<T> to_vector(const T (&arr) [size]) {
@@ -1013,7 +1025,7 @@ struct is_hashable<T,
     typename rxu::types_checked_from<
         typename filtered_hash<T>::result_type,
         typename filtered_hash<T>::argument_type,
-        typename std::result_of<filtered_hash<T>(T)>::type>::type>
+        typename rxu::result_of<filtered_hash<T>(T)>::type>::type>
     : std::true_type {};
 
 }

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -54,11 +54,10 @@ struct result_of<F(TN...)>
 {
     using type = std::invoke_result_t<F, TN...>;
 };
-
-template<class... TN> using result_of_t = typename result_of<TN...>::type;
 #else
-template<class... TN> using result_of_t = typename std::result_of<TN...>::type;
+template<class... TN> using result_of = std::result_of<TN...>;
 #endif
+template<class... TN> using result_of_t = typename result_of<TN...>::type;
 
 template<class T, std::size_t size>
 std::vector<T> to_vector(const T (&arr) [size]) {


### PR DESCRIPTION
Fix for #530, intended to be as minimal as possible. Further testing is required, but I wanted to get this in for discussion.