### PR TITLE
Fix multicast_observer deadlock

### DIFF
--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -38,7 +38,7 @@ class multicast_observer
             , lifetime(cs)
         {
         }
-        std::mutex lock;
+        std::recursive_mutex lock;
         typename mode::type current;
         rxu::error_ptr error;
         composite_subscription lifetime;
@@ -125,13 +125,13 @@ public:
         return make_subscriber<T>(get_id(), get_subscription(), observer<T, detail::multicast_observer<T>>(*this));
     }
     bool has_observers() const {
-        std::unique_lock<std::mutex> guard(b->state->lock);
+        std::unique_lock<std::recursive_mutex> guard(b->state->lock);
         return b->completer && !b->completer->observers.empty();
     }
     template<class SubscriberFrom>
     void add(const SubscriberFrom& sf, observer_type o) const {
         trace_activity().connect(sf, o);
-        std::unique_lock<std::mutex> guard(b->state->lock);
+        std::unique_lock<std::recursive_mutex> guard(b->state->lock);
         switch (b->state->current) {
         case mode::Casting:
             {
@@ -140,7 +140,7 @@ public:
                     o.add([=](){
                         auto b = binder.lock();
                         if (b) {
-                            std::unique_lock<std::mutex> guard(b->state->lock);
+                            std::unique_lock<std::recursive_mutex> guard(b->state->lock);
                             b->completer = std::make_shared<completer_type>(b->state, b->completer);
                         }
                     });
@@ -178,7 +178,7 @@ public:
     void on_next(V v) const {
         auto current_completer = b->current_completer.lock();
         if (!current_completer) {
-            std::unique_lock<std::mutex> guard(b->state->lock);
+            std::unique_lock<std::recursive_mutex> guard(b->state->lock);
             b->current_completer = b->completer;
             current_completer = b->current_completer.lock();
         }
@@ -192,7 +192,7 @@ public:
         }
     }
     void on_error(rxu::error_ptr e) const {
-        std::unique_lock<std::mutex> guard(b->state->lock);
+        std::unique_lock<std::recursive_mutex> guard(b->state->lock);
         if (b->state->current == mode::Casting) {
             b->state->error = e;
             b->state->current = mode::Errored;
@@ -211,7 +211,7 @@ public:
         }
     }
     void on_completed() const {
-        std::unique_lock<std::mutex> guard(b->state->lock);
+        std::unique_lock<std::recursive_mutex> guard(b->state->lock);
         if (b->state->current == mode::Casting) {
             b->state->current = mode::Completed;
             auto s = b->state->lifetime;

--- a/Rx/v2/test/CMakeLists.txt
+++ b/Rx/v2/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_DIR ${RXCPP_DIR}/Rx/v2/test)
 set(TEST_SOURCES
     ${TEST_DIR}/subscriptions/coroutine.cpp
     ${TEST_DIR}/subscriptions/observer.cpp
+    ${TEST_DIR}/subscriptions/race_condition.cpp
     ${TEST_DIR}/subscriptions/subscription.cpp
     ${TEST_DIR}/subjects/subject.cpp
     ${TEST_DIR}/sources/create.cpp

--- a/Rx/v2/test/subscriptions/race_condition.cpp
+++ b/Rx/v2/test/subscriptions/race_condition.cpp
@@ -4,8 +4,11 @@
 #include "rxcpp/operators/rx-merge.hpp"
 #include "rxcpp/rx-scheduler.hpp"
 
-SCENARIO("race condition") {
+SCENARIO("multicast_observer race condition") {
 
+  // We loop this test many many times because it is attempting to trigger a
+  // race condition that is not guaranteed to occur, described in
+  // https://github.com/ReactiveX/RxCpp/issues/555
   for (std::size_t i=0; i < 5000; ++i) {
     auto comp1 = rxcpp::composite_subscription();
     auto mco = rxcpp::subjects::detail::multicast_observer<std::string>(comp1);

--- a/Rx/v2/test/subscriptions/race_condition.cpp
+++ b/Rx/v2/test/subscriptions/race_condition.cpp
@@ -1,0 +1,28 @@
+#include "../test.h"
+#include "rxcpp/rx.hpp"
+#include "rxcpp/operators/rx-observe_on.hpp"
+#include "rxcpp/operators/rx-merge.hpp"
+#include "rxcpp/rx-scheduler.hpp"
+
+SCENARIO("race condition") {
+
+  for (std::size_t i=0; i < 5000; ++i) {
+    auto comp1 = rxcpp::composite_subscription();
+    auto mco = rxcpp::subjects::detail::multicast_observer<std::string>(comp1);
+
+    auto comp2 = rxcpp::composite_subscription();
+    auto obs = rxcpp::observer<std::string>();
+    auto sub = rxcpp::subscriber<std::string>(
+      rxcpp::trace_id::make_next_id_subscriber(),
+      comp2,
+      obs);
+
+    using namespace std::chrono_literals;
+    auto t = std::thread([&](){
+      comp2.unsubscribe();
+    });
+
+    mco.add(mco.get_subscription(), sub);
+    t.join();
+  }
+}


### PR DESCRIPTION
This PR fixes #555 and provides a regression test that minimally recreates the deadlocking issue.

If you checkout `Rx/v2/test/CMakeLists.txt` and `Rx/v2/test/subscriptions/race_condition.cpp` into the current `master` branch and try to run `rxcpp_test_race_condition`, you will most likely find that the test gets permanently deadlocked. The deadlocking result is not guaranteed, since it depends on a race condition that has a very narrow window, but it's very probable that the race condition will occur (at least on my machine, it has been). If it doesn't deadlock on the first try, then the test can be rerun repeatedly until it eventually does get deadlocked.

But if you run the test on this branch, with the changes to `multicast_observer`, you will find that it never gets deadlocked no matter how many times the test is repeated. The deadlock is fixed by simply changing the mutex of `multicast_observer::state_type` to a `std::recursive_mutex` which guarantees that it is safe to recursive lock it (which is what causes the deadlock when using a plain `std::mutex`).

I understand that some people consider `std::recursive_mutex` to be something that should always be avoided, because it may be indicative of a design flaw in the memory access strategy. But after putting a lot of thought into this specific deadlocking issue, I don't see an alternative fix for this without a dramatic redesign of `multicast_observer`.

While this deadlocking is a very rare occurrence, it may be an extremely impactful one. Whenever this occurs, it permanently locks up an entire thread. In my own use case, I have a design pattern where I assign an entire category of operations to be observed on a specific `rxcpp::schedulers::worker` (essentially using the worker to ensure mutually exclusive access to a certain cluster of data), and if that worker ever gets caught in this deadlock, then I'll permanently lose that entire category of operations.

So while it might be desirable to do a redesign to avoid the need for a `std::recursive_mutex` I would strongly encourage using it as a stopgap until an alternative solution can be found and implemented, assuming that might take some time to work out.