### PR TITLE
[FixCrash][Perfomance]Remove unnecessary "this" capture for subjects to prevent crashes for stack subjects variables.

### DIFF
--- a/Rx/v2/src/rxcpp/subjects/rx-behavior.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-behavior.hpp
@@ -91,11 +91,11 @@ public:
 
     observable<T> get_observable() const {
         auto keepAlive = s;
-        return make_observable_dynamic<T>([keepAlive, this](subscriber<T> o){
+        return make_observable_dynamic<T>([keepAlive](subscriber<T> o){
             if (keepAlive.get_subscription().is_subscribed()) {
-                o.on_next(get_value());
+                o.on_next(keepAlive.get_value());
             }
-            keepAlive.add(s.get_subscriber(), std::move(o));
+            keepAlive.add(keepAlive.get_subscriber(), std::move(o));
         });
     }
 };

--- a/Rx/v2/src/rxcpp/subjects/rx-replaysubject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-replaysubject.hpp
@@ -169,8 +169,8 @@ public:
 
     observable<T> get_observable() const {
         auto keepAlive = s;
-        auto observable = make_observable_dynamic<T>([keepAlive, this](subscriber<T> o){
-            for (auto&& value: get_values()) {
+        auto observable = make_observable_dynamic<T>([keepAlive](subscriber<T> o){
+            for (auto&& value: keepAlive.get_values()) {
                 o.on_next(value);
             }
             keepAlive.add(keepAlive.get_subscriber(), std::move(o));


### PR DESCRIPTION
In the case of using replay/behavioral subjects as local variables, it is possible to obtain a crash when the subject variable is destroyed, but the stream is still used.