### PR TITLE
[Perfomance] Significantly reduce amount of copies/moves inside operators 

### DIFF
--- a/Rx/v2/examples/linesfrombytes/main.cpp
+++ b/Rx/v2/examples/linesfrombytes/main.cpp
@@ -53,7 +53,7 @@ int main()
                     }) |
                 as_dynamic();
         }) |
-        tap([](vector<uint8_t>& v){
+        tap([](const vector<uint8_t>& v){
             // print input packet of bytes
             copy(v.begin(), v.end(), ostream_iterator<long>(cout, " "));
             cout << endl;

--- a/Rx/v2/src/rxcpp/operators/rx-all.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-all.hpp
@@ -70,7 +70,7 @@ struct all
               done(false)
         {
         }
-        void on_next(source_value_type v) const {
+        void on_next(const source_value_type& v) const {
             auto filtered = on_exception([&]() {
                 return !this->test(v); },
                 dest);

--- a/Rx/v2/src/rxcpp/operators/rx-all.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-all.hpp
@@ -161,12 +161,12 @@ struct member_overload<is_empty_tag>
         class SourceValue = rxu::value_type_t<Observable>,
         class Enabled = rxu::enable_if_all_true_type_t<
             is_observable<Observable>>,
-        class Predicate = std::function<bool(SourceValue)>,
+        class Predicate = std::function<bool(const SourceValue&)>,
         class IsEmpty = rxo::detail::all<SourceValue, rxu::decay_t<Predicate>>,
         class Value = rxu::value_type_t<IsEmpty>>
     static auto member(Observable&& o)
     -> decltype(o.template lift<Value>(IsEmpty(nullptr))) {
-        return  o.template lift<Value>(IsEmpty([](SourceValue) { return false; }));
+        return  o.template lift<Value>(IsEmpty([](const SourceValue&) { return false; }));
     }
 
     template<class... AN>

--- a/Rx/v2/src/rxcpp/operators/rx-amb.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-amb.hpp
@@ -171,8 +171,8 @@ struct amb
                     state->out,
                     innercs,
                 // on_next
-                    [state, st, current_id](value_type ct) {
-                        state->out.on_next(std::move(ct));
+                    [state, st, current_id](auto&& ct) {
+                        state->out.on_next(std::forward<decltype(ct)>(ct));
                         if (!state->firstEmitted) {
                             state->firstEmitted = true;
                             auto do_unsubscribe = [](composite_subscription cs) {

--- a/Rx/v2/src/rxcpp/operators/rx-any.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-any.hpp
@@ -204,12 +204,13 @@ struct member_overload<contains_tag>
         class SourceValue = rxu::value_type_t<Observable>,
         class Enabled = rxu::enable_if_all_true_type_t<
             is_observable<Observable>>,
-        class Predicate = std::function<bool(T)>,
+        class Predicate = std::function<bool(const rxu::decay_t<T>&)>,
         class Any = rxo::detail::any<SourceValue, rxu::decay_t<Predicate>>,
         class Value = rxu::value_type_t<Any>>
     static auto member(Observable&& o, T&& value)
     -> decltype(o.template lift<Value>(Any(nullptr))) {
-        return  o.template lift<Value>(Any([value](T n) { return n == value; }));
+        auto valueAsShared = std::make_shared<rxu::decay_t<T>>(std::forward<T>(value));
+        return  o.template lift<Value>(Any([valueAsShared](const rxu::decay_t<T>& n) { return n == *valueAsShared; }));
     }
 
     template<class... AN>

--- a/Rx/v2/src/rxcpp/operators/rx-any.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-any.hpp
@@ -77,7 +77,7 @@ struct any
               done(false)
         {
         }
-        void on_next(source_value_type v) const {
+        void on_next(const source_value_type& v) const {
             auto filtered = on_exception([&]() {
                 return !this->test(v); },
                 dest);

--- a/Rx/v2/src/rxcpp/operators/rx-buffer_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-buffer_count.hpp
@@ -84,9 +84,11 @@ struct buffer_count
             , cursor(0)
         {
         }
-        void on_next(T v) const {
+
+        void on_next(const T& v) const {
             if (cursor++ % this->skip == 0) {
                 chunks.emplace_back();
+                chunks.back().reserve(this->count);
             }
             for(auto& chunk : chunks) {
                 chunk.push_back(v);

--- a/Rx/v2/src/rxcpp/operators/rx-buffer_time.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-buffer_time.hpp
@@ -182,7 +182,7 @@ struct buffer_with_time
                     localState->worker.schedule(selectedCreate.get());
                 });
         }
-        void on_next(T v) const {
+        void on_next(const T& v) const {
             auto localState = state;
             auto work = [v, localState](const rxsc::schedulable&){
                 for(auto& chunk : localState->chunks) {

--- a/Rx/v2/src/rxcpp/operators/rx-buffer_time_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-buffer_time_count.hpp
@@ -163,7 +163,7 @@ struct buffer_with_time_or_count
             return std::function<void(const rxsc::schedulable&)>(selectedProduce.get());
         }
 
-        void on_next(T v) const {
+        void on_next(const T& v) const {
             auto localState = state;
             auto work = [v, localState](const rxsc::schedulable& self){
                 localState->chunk.push_back(v);

--- a/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
@@ -168,8 +168,7 @@ struct combine_latest : public operator_base<rxu::value_type_t<combine_latest_tr
 
                 if (state->valuesSet == sizeof... (ObservableN)) {
                     auto values = rxu::surely(state->latest);
-                    auto selectedResult = rxu::apply(std::move(values), state->selector);
-                    state->out.on_next(std::move(selectedResult));
+                    state->out.on_next(rxu::apply(std::move(values), state->selector));
                 }
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
@@ -157,19 +157,19 @@ struct combine_latest : public operator_base<rxu::value_type_t<combine_latest_tr
             state->out,
             innercs,
         // on_next
-            [state](source_value_type st) {
+            [state](auto&& st) {
                 auto& value = std::get<Index>(state->latest);
 
                 if (value.empty()) {
                     ++state->valuesSet;
                 }
 
-                value.reset(st);
+                value.reset(std::forward<decltype(st)>(st));
 
                 if (state->valuesSet == sizeof... (ObservableN)) {
                     auto values = rxu::surely(state->latest);
-                    auto selectedResult = rxu::apply(values, state->selector);
-                    state->out.on_next(selectedResult);
+                    auto selectedResult = rxu::apply(std::move(values), state->selector);
+                    state->out.on_next(std::move(selectedResult));
                 }
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-concat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat.hpp
@@ -139,7 +139,7 @@ struct concat
                     state->out,
                     collectionLifetime,
                 // on_next
-                    [state, st](auto&& ct) {
+                    [state](auto&& ct) {
                         state->out.on_next(std::forward<decltype(ct)>(ct));
                     },
                 // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-concat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat.hpp
@@ -139,8 +139,8 @@ struct concat
                     state->out,
                     collectionLifetime,
                 // on_next
-                    [state, st](value_type ct) {
-                        state->out.on_next(ct);
+                    [state, st](auto&& ct) {
+                        state->out.on_next(std::forward<decltype(ct)>(ct));
                     },
                 // on_error
                     [state](rxu::error_ptr e) {

--- a/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
@@ -154,7 +154,7 @@ struct concat_map
                 subscribe_to(std::make_shared<source_value_type>(std::move(st)));
             }
 
-            void subscribe_to(std::shared_ptr<source_value_type> st)
+            void subscribe_to(std::shared_ptr<source_value_type>&& st)
             {
                 auto state = this->shared_from_this();
 

--- a/Rx/v2/src/rxcpp/operators/rx-delay.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-delay.hpp
@@ -117,10 +117,12 @@ struct delay
             });
         }
 
-        void on_next(T v) const {
+        template<typename U>
+        void on_next(U&& v) const {
             auto localState = state;
-            auto work = [v, localState](const rxsc::schedulable&){
-                localState->dest.on_next(v);
+            auto vAsShared  = std::make_shared<T>(std::forward<U>(v));
+            auto work = [vAsShared, localState](const rxsc::schedulable&){
+                localState->dest.on_next(std::move(*vAsShared));
             };
             auto selectedWork = on_exception(
                 [&](){return localState->coordinator.act(work);},

--- a/Rx/v2/src/rxcpp/operators/rx-distinct.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-distinct.hpp
@@ -55,10 +55,11 @@ struct distinct
                 : dest(d)
         {
         }
-        void on_next(source_value_type v) const {
+        template<typename U>
+        void on_next(U&& v) const {
             if (remembered.empty() || remembered.count(v) == 0) {
                 remembered.insert(v);
-                dest.on_next(v);
+                dest.on_next(std::forward<U>(v));
             }
         }
         void on_error(rxu::error_ptr e) const {

--- a/Rx/v2/src/rxcpp/operators/rx-distinct_until_changed.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-distinct_until_changed.hpp
@@ -68,10 +68,11 @@ struct distinct_until_changed
             , pred(std::move(pred))
         {
         }
-        void on_next(source_value_type v) const {
+        template<typename U>
+        void on_next(U&& v) const {
             if (remembered.empty() || !pred(v, remembered.get())) {
                 remembered.reset(v);
-                dest.on_next(v);
+                dest.on_next(std::forward<U>(v));
             }
         }
         void on_error(rxu::error_ptr e) const {

--- a/Rx/v2/src/rxcpp/operators/rx-element_at.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-element_at.hpp
@@ -71,9 +71,10 @@ struct element_at {
               current(0)
         {
         }
-        void on_next(source_value_type v) const {
+        template<typename U>
+        void on_next(U&& v) const {
             if (current++ == this->index) {
-                dest.on_next(v);
+                dest.on_next(std::forward<U>(v));
                 dest.on_completed();
             }
         }

--- a/Rx/v2/src/rxcpp/operators/rx-finally.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-finally.hpp
@@ -67,8 +67,9 @@ struct finally
             : dest(std::move(d))
         {
         }
-        void on_next(source_value_type v) const {
-            dest.on_next(v);
+        template<typename U>
+        void on_next(U&& v) const {
+            dest.on_next(std::forward<U>(v));
         }
         void on_error(rxu::error_ptr e) const {
             dest.on_error(e);

--- a/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
@@ -195,7 +195,7 @@ struct flat_map
                     innercs,
                 // on_next
                     [state, stAsShared](collection_value_type ct) {
-                        auto selectedResult = state->selectResult(*stAsShared, std::move(ct));
+                        auto selectedResult = state->selectResult(std::move(*stAsShared), std::move(ct));
                         state->out.on_next(std::move(selectedResult));
                     },
                 // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-ignore_elements.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-ignore_elements.hpp
@@ -52,7 +52,7 @@ struct ignore_elements {
         {
         }
 
-        void on_next(source_value_type) const {
+        void on_next(const source_value_type&) const {
             // no-op; ignore element
         }
 

--- a/Rx/v2/src/rxcpp/operators/rx-map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-map.hpp
@@ -66,16 +66,15 @@ struct map
             , selector(std::move(s))
         {
         }
+
         template<class Value>
-        void on_next(Value&& v) const {
-            auto selected = on_exception(
-                [&](){
-                    return this->selector(std::forward<Value>(v));},
-                dest);
-            if (selected.empty()) {
-                return;
-            }
-            dest.on_next(std::move(selected.get()));
+        void on_next(Value&& v) const
+        {
+            on_exception_no_return([&]()
+                                   {
+                                       dest.on_next(this->selector(std::forward<Value>(v)));
+                                   },
+                                   dest);
         }
         void on_error(rxu::error_ptr e) const {
             dest.on_error(e);

--- a/Rx/v2/src/rxcpp/operators/rx-merge.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-merge.hpp
@@ -169,8 +169,8 @@ struct merge
                     state->out,
                     innercs,
                 // on_next
-                    [state, st](value_type ct) {
-                        state->out.on_next(std::move(ct));
+                    [state, st](auto&& ct) {
+                        state->out.on_next(std::forward<decltype(ct)>(ct));
                     },
                 // on_error
                     [state](rxu::error_ptr e) {

--- a/Rx/v2/src/rxcpp/operators/rx-merge_delay_error.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-merge_delay_error.hpp
@@ -163,8 +163,8 @@ struct merge_delay_error
                                         state->out,
                                         innercs,
                                 // on_next
-                                        [state, st](value_type ct) {
-                                                state->out.on_next(std::move(ct));
+                                        [state, st](auto&& ct) {
+                                                state->out.on_next(std::forward<decltype(ct)>(ct));
                                         },
                                 // on_error
                                         [state](rxu::error_ptr e) {

--- a/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
@@ -146,7 +146,7 @@ struct observe_on
                                 }
                                 auto notification = std::move(drain_queue.front());
                                 drain_queue.pop_front();
-                                notification->accept(destination);
+                                std::move(*notification).accept(destination);
                                 std::unique_lock<std::mutex> guard(lock);
                                 self();
                                 if (lifetime.is_subscribed()) break;

--- a/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
@@ -183,10 +183,11 @@ struct observe_on
         {
         }
 
-        void on_next(source_value_type v) const {
+        template<typename U>
+        void on_next(U&& v) const {
             std::unique_lock<std::mutex> guard(state->lock);
             if (state->current == mode::Errored || state->current == mode::Disposed) { return; }
-            state->fill_queue.push_back(notification_type::on_next(std::move(v)));
+            state->fill_queue.push_back(notification_type::on_next(std::forward<U>(v)));
             state->ensure_processing(guard);
         }
         void on_error(rxu::error_ptr e) const {

--- a/Rx/v2/src/rxcpp/operators/rx-on_error_resume_next.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-on_error_resume_next.hpp
@@ -72,8 +72,9 @@ struct on_error_resume_next
         {
             dest.add(lifetime);
         }
-        void on_next(value_type v) const {
-            dest.on_next(std::move(v));
+        template<typename U>
+        void on_next(U&& v) const {
+            dest.on_next(std::forward<U>(v));
         }
         void on_error(rxu::error_ptr e) const {
             auto selected = on_exception(

--- a/Rx/v2/src/rxcpp/operators/rx-pairwise.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-pairwise.hpp
@@ -58,14 +58,15 @@ struct pairwise
             : dest(std::move(d))
         {
         }
-        void on_next(source_value_type v) const {
+        template<typename U>
+        void on_next(U&& v) const {
             if (remembered.empty()) {
-                remembered.reset(v);
+                remembered.reset(std::forward<U>(v));
                 return;
             }
 
-            dest.on_next(std::make_tuple(remembered.get(), v));
-            remembered.reset(v);
+            dest.on_next(std::make_tuple(std::move(remembered.get()), v));
+            remembered.reset(std::forward<U>(v));
         }
         void on_error(rxu::error_ptr e) const {
             dest.on_error(e);

--- a/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
@@ -161,9 +161,8 @@ struct reduce : public operator_base<rxu::value_type_t<reduce_traits<T, Observab
         state->source.subscribe(
             state->out,
         // on_next
-            [state](T t) {
-                seed_type next = state->accumulator(std::move(state->current), std::move(t));
-                state->current = std::move(next);
+            [state](auto&& t) {
+                state->current = state->accumulator(std::move(state->current), std::forward<decltype(t)>(t));
             },
         // on_error
             [state](rxu::error_ptr e) {

--- a/Rx/v2/src/rxcpp/operators/rx-retry-repeat-common.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-retry-repeat-common.hpp
@@ -38,8 +38,8 @@ namespace rxcpp {
                                     state->out,
                                     state->source_lifetime,
                                     // on_next
-                                    [state](T t) {
-                                      state->out.on_next(t);
+                                    [state](auto&& t) {
+                                      state->out.on_next(std::forward<decltype(t)>(t));
                                     },
                                     // on_error
                                     [state](rxu::error_ptr e) {

--- a/Rx/v2/src/rxcpp/operators/rx-sample_time.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-sample_time.hpp
@@ -117,7 +117,7 @@ struct sample_with_time
 
             auto produce_sample = [localState](const rxsc::schedulable&) {
                 if(!localState->value.empty()) {
-                    localState->dest.on_next(*localState->value);
+                    localState->dest.on_next(std::move(* localState->value));
                     localState->value.reset();
                 }
             };
@@ -135,8 +135,9 @@ struct sample_with_time
                     localState->worker.schedule(selectedProduce.get());
                 });
         }
-        
-        void on_next(T v) const {
+
+        template<typename U>
+        void on_next(U&& v) const {
             auto localState = state;
             auto work = [v, localState](const rxsc::schedulable&) {
                 localState->value.reset(v);

--- a/Rx/v2/src/rxcpp/operators/rx-scan.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-scan.hpp
@@ -85,8 +85,8 @@ struct scan : public operator_base<rxu::decay_t<Seed>>
         state->source.subscribe(
             state->out,
         // on_next
-            [state](T t) {
-                state->result = state->accumulator(state->result, t);
+            [state](auto&& t) {
+                state->result = state->accumulator(std::move(state->result), std::forward<decltype(t)>(t));
                 state->out.on_next(state->result);
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-skip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip.hpp
@@ -99,13 +99,13 @@ struct skip : public operator_base<T>
         // split subscription lifetime
             source_lifetime,
         // on_next
-            [state](T t) {
+            [state](auto&& t) {
                 if (state->mode_value == mode::skipping) {
                     if (--state->count == 0) {
                         state->mode_value = mode::triggered;
                     }
                 } else {
-                    state->out.on_next(t);
+                    state->out.on_next(std::forward<decltype(t)>(t));
                 }
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-skip_last.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip_last.hpp
@@ -91,15 +91,15 @@ struct skip_last : public operator_base<T>
         // split subscription lifetime
             source_lifetime,
         // on_next
-            [state](T t) {
+            [state](auto&& t) {
                 if(state->count > 0) {
                     if (state->items.size() == state->count) {
                         state->out.on_next(std::move(state->items.front()));
                         state->items.pop();
                     }
-                    state->items.push(t);
+                    state->items.emplace(std::forward<decltype(t)>(t));
                 } else {
-                    state->out.on_next(t);
+                    state->out.on_next(std::forward<decltype(t)>(t));
                 }
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-skip_until.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip_until.hpp
@@ -167,11 +167,11 @@ struct skip_until : public operator_base<T>
         // split subscription lifetime
             state->source_lifetime,
         // on_next
-            [state](T t) {
+            [state](auto&& t) {
                 if (state->mode_value != mode::triggered) {
                     return;
                 }
-                state->out.on_next(t);
+                state->out.on_next(std::forward<decltype(t)>(t));
             },
         // on_error
             [state](rxu::error_ptr e) {

--- a/Rx/v2/src/rxcpp/operators/rx-skip_while.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip_while.hpp
@@ -68,11 +68,13 @@ struct skip_while
                   pass(false)
         {
         }
-        void on_next(source_value_type v) {
+
+        template<typename U>
+        void on_next(U&& v) {
             if(pass || !test(v))
             {
                 pass = true;
-                dest.on_next(v);
+                dest.on_next(std::forward<U>(v));
             }
         }
         void on_error(rxu::error_ptr e) const {

--- a/Rx/v2/src/rxcpp/operators/rx-switch_if_empty.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-switch_if_empty.hpp
@@ -72,9 +72,10 @@ struct switch_if_empty
         {
             dest.add(lifetime);
         }
-        void on_next(source_value_type v) const {
+        template<typename U>
+        void on_next(U&& v) const {
             is_empty = false;
-            dest.on_next(std::move(v));
+            dest.on_next(std::forward<U>(v));
         }
         void on_error(rxu::error_ptr e) const {
             dest.on_error(std::move(e));
@@ -160,9 +161,9 @@ struct member_overload<default_if_empty_tag>
         class SourceValue = rxu::value_type_t<Observable>,
         class BackupSource = decltype(rxs::from(std::declval<SourceValue>())),
         class DefaultIfEmpty = rxo::detail::switch_if_empty<SourceValue, BackupSource>>
-    static auto member(Observable&& o, Value v)
-        -> decltype(o.template lift<SourceValue>(DefaultIfEmpty(rxs::from(std::move(v))))) {
-        return      o.template lift<SourceValue>(DefaultIfEmpty(rxs::from(std::move(v))));
+    static auto member(Observable&& o, Value&& v)
+        -> decltype(o.template lift<SourceValue>(DefaultIfEmpty(rxs::from(std::forward<Value>(v))))) {
+        return      o.template lift<SourceValue>(DefaultIfEmpty(rxs::from(std::forward<Value>(v))));
     }
 
     template<class... AN>

--- a/Rx/v2/src/rxcpp/operators/rx-switch_on_next.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-switch_on_next.hpp
@@ -151,8 +151,8 @@ struct switch_on_next
                     state->out,
                     state->inner_lifetime,
                 // on_next
-                    [state, st](collection_value_type ct) {
-                        state->out.on_next(std::move(ct));
+                    [state, st](auto&& ct) {
+                        state->out.on_next(std::forward<decltype(ct)>(ct));
                     },
                 // on_error
                     [state](rxu::error_ptr e) {

--- a/Rx/v2/src/rxcpp/operators/rx-take.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take.hpp
@@ -98,13 +98,13 @@ struct take : public operator_base<T>
         // split subscription lifetime
             source_lifetime,
         // on_next
-            [state, source_lifetime](T t) {
+            [state, source_lifetime](auto&& t) {
                 if (state->mode_value < mode::triggered) {
                     if (--state->count > 0) {
-                        state->out.on_next(t);
+                        state->out.on_next(std::forward<decltype(t)>(t));
                     } else {
                         state->mode_value = mode::triggered;
-                        state->out.on_next(t);
+                        state->out.on_next(std::forward<decltype(t)>(t));
                         // must shutdown source before signaling completion
                         source_lifetime.unsubscribe();
                         state->out.on_completed();

--- a/Rx/v2/src/rxcpp/operators/rx-take_last.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take_last.hpp
@@ -91,12 +91,12 @@ struct take_last : public operator_base<T>
         // split subscription lifetime
             source_lifetime,
         // on_next
-            [state, source_lifetime](T t) {
+            [state, source_lifetime](auto&& t) {
                 if(state->count > 0) {
                     if (state->items.size() == state->count) {
                         state->items.pop();
                     }
-                    state->items.push(t);
+                    state->items.emplace(std::forward<decltype(t)>(t));
                 }
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-take_until.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take_until.hpp
@@ -170,12 +170,12 @@ struct take_until : public operator_base<T>
         // split subscription lifetime
             state->source_lifetime,
         // on_next
-            [state](T t) {
+            [state](auto&& t) {
                 //
                 // everything is crafted to minimize the overhead of this function.
                 //
                 if (state->mode_value < mode::triggered) {
-                    state->out.on_next(t);
+                    state->out.on_next(std::forward<decltype(t)>(t));
                 }
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-take_while.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take_while.hpp
@@ -66,9 +66,10 @@ struct take_while
                 , test(std::move(t))
         {
         }
-        void on_next(source_value_type v) const {
+        template<typename U>
+        void on_next(U&& v) const {
             if (test(v)) {
-                dest.on_next(v);
+                dest.on_next(std::forward<U>(v));
             } else {
                 dest.on_completed();
             }

--- a/Rx/v2/src/rxcpp/operators/rx-tap.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-tap.hpp
@@ -88,9 +88,10 @@ struct tap
             , out(std::move(o))
         {
         }
-        void on_next(source_value_type v) const {
+        template<typename U>
+        void on_next(U&& v) const {
             out.on_next(v);
-            dest.on_next(v);
+            dest.on_next(std::forward<U>(v));
         }
         void on_error(rxu::error_ptr e) const {
             out.on_error(e);

--- a/Rx/v2/src/rxcpp/operators/rx-time_interval.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-time_interval.hpp
@@ -79,7 +79,7 @@ struct time_interval
         {
         }
 
-        void on_next(source_value_type) const {
+        void on_next(const source_value_type&) const {
             time_point now = coord.now();
             dest.on_next(now - last);
             last = now;

--- a/Rx/v2/src/rxcpp/operators/rx-timeout.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-timeout.hpp
@@ -160,13 +160,13 @@ struct timeout
             return std::function<void(const rxsc::schedulable&)>(selectedProduce.get());
         }
 
-        void on_next(T v) const {
+        void on_next(const T& v) const {
             auto localState = state;
             auto work = [v, localState](const rxsc::schedulable&) {
                 auto new_id = ++localState->index;
                 auto produce_time = localState->worker.now() + localState->period;
 
-                localState->dest.on_next(v);
+                localState->dest.on_next(std::move(v));
                 localState->worker.schedule(produce_time, produce_timeout(new_id, localState));
             };
             auto selectedWork = on_exception(

--- a/Rx/v2/src/rxcpp/operators/rx-timestamp.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-timestamp.hpp
@@ -75,8 +75,9 @@ struct timestamp
         {
         }
 
-        void on_next(source_value_type v) const {
-            dest.on_next(std::make_pair(v, coord.now()));
+        template<typename U>
+        void on_next(U&& v) const {
+            dest.on_next(std::make_pair(std::forward<U>(v), coord.now()));
         }
         void on_error(rxu::error_ptr e) const {
             dest.on_error(e);

--- a/Rx/v2/src/rxcpp/operators/rx-window.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window.hpp
@@ -86,8 +86,8 @@ struct window
             subj.push_back(rxcpp::subjects::subject<T>());
             dest.on_next(subj[0].get_observable().as_dynamic());
         }
-        void on_next(T v) const {
-            for (auto s : subj) {
+        void on_next(const T& v) const {
+            for (const auto& s : subj) {
                 s.get_subscriber().on_next(v);
             }
 

--- a/Rx/v2/src/rxcpp/operators/rx-window_toggle.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_toggle.hpp
@@ -202,10 +202,10 @@ struct window_toggle
             source->subscribe(std::move(selectedSink.get()));
         }
 
-        void on_next(T v) const {
+        void on_next(const T& v) const {
             auto localState = state;
             auto work = [v, localState](const rxsc::schedulable&){
-                for (auto s : localState->subj) {
+                for (const auto& s : localState->subj) {
                     s.get_subscriber().on_next(v);
                 }
             };

--- a/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
@@ -157,19 +157,18 @@ struct with_latest_from : public operator_base<rxu::value_type_t<with_latest_fro
             state->out,
             innercs,
         // on_next
-            [state](source_value_type st) {
+            [state](auto&& st) {
                 auto& value = std::get<Index>(state->latest);
 
                 if (value.empty()) {
                     ++state->valuesSet;
                 }
 
-                value.reset(st);
+                value.reset(std::forward<decltype(st)>(st));
 
                 if (state->valuesSet == sizeof... (ObservableN) && Index == 0) {
                     auto values = rxu::surely(state->latest);
-                    auto selectedResult = rxu::apply(values, state->selector);
-                    state->out.on_next(selectedResult);
+                    state->out.on_next(rxu::apply(std::move(values), state->selector));
                 }
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-zip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-zip.hpp
@@ -191,12 +191,11 @@ struct zip : public operator_base<rxu::value_type_t<zip_traits<Coordination, Sel
             state->out,
             innercs,
         // on_next
-            [state](source_value_type st) {
+            [state](auto&& st) {
                 auto& values = std::get<Index>(state->pending).values;
-                values.push_back(st);
+                values.emplace_back(std::forward<decltype(st)>(st));
                 if (rxu::apply_to_each(state->pending, values_not_empty(), rxu::all_values_true())) {
-                    auto selectedResult = rxu::apply_to_each(state->pending, extract_value_front(), state->selector);
-                    state->out.on_next(selectedResult);
+                    state->out.on_next(rxu::apply_to_each(state->pending, extract_value_front(), state->selector));
                 }
                 if (rxu::apply_to_each(state->pending, source_completed_values_empty(), rxu::any_value_true())) {
                     state->out.on_completed();

--- a/Rx/v2/src/rxcpp/rx-notification.hpp
+++ b/Rx/v2/src/rxcpp/rx-notification.hpp
@@ -122,8 +122,8 @@ private:
     typedef detail::notification_base<T> base;
 
     struct on_next_notification : public base {
-        on_next_notification(T value) : value(std::move(value)) {
-        }
+        on_next_notification(T&& value) : value(std::move(value)) {}
+        on_next_notification(const T& value) : value(value) {}
         on_next_notification(const on_next_notification& o) : value(o.value) {}
         on_next_notification(const on_next_notification&& o) : value(std::move(o.value)) {}
         on_next_notification& operator=(on_next_notification o) { value = std::move(o.value); return *this; }
@@ -206,8 +206,8 @@ private:
 
 public:
     template<typename U>
-    static type on_next(U value) {
-        return std::make_shared<on_next_notification>(std::move(value));
+    static type on_next(U&& value) {
+        return std::make_shared<on_next_notification>(std::forward<U>(value));
     }
 
     static type on_completed() {

--- a/Rx/v2/src/rxcpp/rx-notification.hpp
+++ b/Rx/v2/src/rxcpp/rx-notification.hpp
@@ -53,8 +53,8 @@ struct notification_base
 
     virtual void out(std::ostream& out) const =0;
     virtual bool equals(const type& other) const = 0;
-    virtual void accept(const observer_type& o) const =0;
-    virtual void accept(const observer_type& o) =0;
+    virtual void accept(const observer_type& o) const & =0;
+    virtual void accept(const observer_type& o) && =0;
 };
 
 template<class T>
@@ -140,11 +140,11 @@ private:
                 })));
             return result;
         }
-        void accept(const typename base::observer_type& o) const override{
+        void accept(const typename base::observer_type& o) const & override{
             o.on_next(value);
         }
 
-        void accept(const typename base::observer_type& o) override {
+        void accept(const typename base::observer_type& o) && override {
             o.on_next(std::move(value));
         }
         T value;
@@ -169,11 +169,11 @@ private:
             })));
             return result;
         }
-        void accept(const typename base::observer_type& o) const override{
+        void accept(const typename base::observer_type& o) const & override{
             o.on_error(ep);
         }
 
-        void accept(const typename base::observer_type& o) override{
+        void accept(const typename base::observer_type& o) && override{
             o.on_error(ep);
         }
         const rxu::error_ptr ep;
@@ -192,11 +192,11 @@ private:
             })));
             return result;
         }
-        void accept(const typename base::observer_type& o) const override{
+        void accept(const typename base::observer_type& o) const & override{
             o.on_completed();
         }
 
-        void accept(const typename base::observer_type& o) override{
+        void accept(const typename base::observer_type& o) && override{
             o.on_completed();
         }
     };

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -181,7 +181,7 @@ class blocking_observable
         // keep any error to rethrow at the end.
         auto scbr = make_subscriber<T>(
             dest,
-            [&](T t){dest.on_next(t);},
+            [&](auto&& t){dest.on_next(std::forward<decltype(t)>(t));},
             [&](rxu::error_ptr e){
                 if (do_rethrow) {
                     error = e;

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -52,7 +52,7 @@ struct OnNextForward
         onnext(s, t);
     }
     void operator()(state_t& s, T&& t) const {
-        onnext(s, t);
+        onnext(s, std::move(t));
     }
 };
 template<class T, class State>
@@ -64,7 +64,7 @@ struct OnNextForward<T, State, void>
         s.on_next(t);
     }
     void operator()(state_t& s, T&& t) const {
-        s.on_next(t);
+        s.on_next(std::move(t));
     }
 };
 

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -637,25 +637,43 @@ struct maybe_from_result
 template<class F, class OnError>
 auto on_exception(const F& f, const OnError& c)
     ->  typename std::enable_if<detail::is_on_error<OnError>::value, typename detail::maybe_from_result<F>::type>::type {
-    typename detail::maybe_from_result<F>::type r;
     RXCPP_TRY {
-        r.reset(f());
+        return f();
     } RXCPP_CATCH(...) {
         c(rxu::current_exception());
     }
-    return r;
+    return {};
 }
 
 template<class F, class Subscriber>
 auto on_exception(const F& f, const Subscriber& s)
     ->  typename std::enable_if<is_subscriber<Subscriber>::value, typename detail::maybe_from_result<F>::type>::type {
-    typename detail::maybe_from_result<F>::type r;
     RXCPP_TRY {
-        r.reset(f());
+        return f();
     } RXCPP_CATCH(...) {
         s.on_error(rxu::current_exception());
     }
-    return r;
+    return {};
+}
+
+template<class F, class OnError>
+auto on_exception_no_return(const F& f, const OnError& c)
+    ->  typename std::enable_if<detail::is_on_error<OnError>::value, void>::type {
+    RXCPP_TRY {
+        f();
+    } RXCPP_CATCH(...) {
+        c(rxu::current_exception());
+    };
+}
+
+template<class F, class Subscriber>
+auto on_exception_no_return(const F& f, const Subscriber& s)
+    ->  typename std::enable_if<is_subscriber<Subscriber>::value, void>::type {
+    RXCPP_TRY {
+        f();
+    } RXCPP_CATCH(...) {
+        s.on_error(rxu::current_exception());
+    }
 }
 
 }

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -48,7 +48,7 @@ struct OnNextForward
     OnNextForward() : onnext() {}
     explicit OnNextForward(onnext_t on) : onnext(std::move(on)) {}
     onnext_t onnext;
-    void operator()(state_t& s, T& t) const {
+    void operator()(state_t& s, const T& t) const {
         onnext(s, t);
     }
     void operator()(state_t& s, T&& t) const {
@@ -60,7 +60,7 @@ struct OnNextForward<T, State, void>
 {
     using state_t = rxu::decay_t<State>;
     OnNextForward() {}
-    void operator()(state_t& s, T& t) const {
+    void operator()(state_t& s, const T& t) const {
         s.on_next(t);
     }
     void operator()(state_t& s, T&& t) const {
@@ -237,8 +237,7 @@ public:
         oncompleted = std::move(o.oncompleted);
         return *this;
     }
-
-    void on_next(T& t) const {
+    void on_next(const T& t) const {
         onnext(state, t);
     }
     void on_next(T&& t) const {
@@ -325,8 +324,7 @@ public:
         oncompleted = std::move(o.oncompleted);
         return *this;
     }
-
-    void on_next(T& t) const {
+    void on_next(const T& t) const {
         onnext(t);
     }
     void on_next(T&& t) const {
@@ -350,7 +348,7 @@ template<class T>
 struct virtual_observer : public std::enable_shared_from_this<virtual_observer<T>>
 {
     virtual ~virtual_observer() {}
-    virtual void on_next(T&) const {};
+    virtual void on_next(const T&) const {};
     virtual void on_next(T&&) const {};
     virtual void on_error(rxu::error_ptr) const {};
     virtual void on_completed() const {};
@@ -365,16 +363,16 @@ struct specific_observer : public virtual_observer<T>
     }
 
     Observer destination;
-    virtual void on_next(T& t) const {
+    void on_next(const T& t) const override {
         destination.on_next(t);
     }
-    virtual void on_next(T&& t) const {
+    void on_next(T&& t) const override{
         destination.on_next(std::move(t));
     }
-    virtual void on_error(rxu::error_ptr e) const {
+    void on_error(rxu::error_ptr e) const override{
         destination.on_error(e);
     }
-    virtual void on_completed() const {
+    void on_completed() const override {
         destination.on_completed();
     }
 };

--- a/Rx/v2/src/rxcpp/rx-subscriber.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscriber.hpp
@@ -48,10 +48,10 @@ class subscriber : public subscriber_base<T>
         {
         }
         template<class U>
-        void operator()(U u) {
+        void operator()(U&& u) {
             trace_activity().on_next_enter(*that, u);
             RXCPP_TRY {
-                that->destination.on_next(std::move(u));
+                that->destination.on_next(std::forward<U>(u));
                 do_unsubscribe = false;
             } RXCPP_CATCH(...) {
                 auto ex = rxu::current_exception();

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -138,30 +138,30 @@ using enable_if_all_true_type_t = typename std::enable_if<all_true_type<BN...>::
 
 struct all_values_true {
     template<class... ValueN>
-    bool operator()(ValueN... vn) const;
+    bool operator()(const ValueN&... vn) const;
 
     template<class Value0>
-    bool operator()(Value0 v0) const {
+    bool operator()(const Value0& v0) const {
         return v0;
     }
 
     template<class Value0, class... ValueN>
-    bool operator()(Value0 v0, ValueN... vn) const {
+    bool operator()(const Value0& v0, const ValueN&... vn) const {
         return v0 && all_values_true()(vn...);
     }
 };
 
 struct any_value_true {
     template<class... ValueN>
-    bool operator()(ValueN... vn) const;
+    bool operator()(const ValueN&... vn) const;
 
     template<class Value0>
-    bool operator()(Value0 v0) const {
+    bool operator()(const Value0& v0) const {
         return v0;
     }
 
     template<class Value0, class... ValueN>
-    bool operator()(Value0 v0, ValueN... vn) const {
+    bool operator()(const Value0& v0, const ValueN&... vn) const {
         return v0 || any_value_true()(vn...);
     }
 };

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -206,10 +206,10 @@ struct value_type_from<T, typename types_checked_from<value_type_t<T>>::type>
     : public std::true_type {typedef value_type_t<T> type;};
 
 namespace detail {
-template<class F, class... ParamN, int... IndexN>
-auto apply(std::tuple<ParamN...> p, values<int, IndexN...>, F&& f)
-    -> decltype(f(std::forward<ParamN>(std::get<IndexN>(p))...)) {
-    return      f(std::forward<ParamN>(std::get<IndexN>(p))...);
+template<class F, class Tuple, int... IndexN>
+auto apply(Tuple&& p, values<int, IndexN...>, F&& f)
+    -> decltype(f(std::get<IndexN>(std::forward<Tuple>(p))...)) {
+    return      f(std::get<IndexN>(std::forward<Tuple>(p))...);
 }
 
 template<class F_inner, class F_outer, class... ParamN, int... IndexN>
@@ -226,9 +226,15 @@ auto apply_to_each(std::tuple<ParamN...>& p, values<int, IndexN...>, const F_inn
 
 }
 template<class F, class... ParamN>
-auto apply(std::tuple<ParamN...> p, F&& f)
+auto apply(std::tuple<ParamN...>&& p, F&& f)
     -> decltype(detail::apply(std::move(p), typename values_from<int, sizeof...(ParamN)>::type(), std::forward<F>(f))) {
     return      detail::apply(std::move(p), typename values_from<int, sizeof...(ParamN)>::type(), std::forward<F>(f));
+}
+
+template<class F, class... ParamN>
+auto apply(const std::tuple<ParamN...>& p, F&& f)
+    -> decltype(detail::apply(p, typename values_from<int, sizeof...(ParamN)>::type(), std::forward<F>(f))) {
+    return      detail::apply(p, typename values_from<int, sizeof...(ParamN)>::type(), std::forward<F>(f));
 }
 
 template<class F_inner, class F_outer, class... ParamN>
@@ -699,12 +705,7 @@ namespace detail {
     struct surely
     {
         template<class... T>
-        auto operator()(T... t)
-            -> decltype(std::make_tuple(t.get()...)) {
-            return      std::make_tuple(t.get()...);
-        }
-        template<class... T>
-        auto operator()(T... t) const
+        auto operator()(const T&... t) const
             -> decltype(std::make_tuple(t.get()...)) {
             return      std::make_tuple(t.get()...);
         }

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -310,14 +310,9 @@ template<int Index>
 struct take_at
 {
     template<class... ParamN>
-    auto operator()(ParamN... pn)
+    auto operator()(const ParamN&... pn) const
         -> typename std::tuple_element<Index, std::tuple<decay_t<ParamN>...>>::type {
-        return                std::get<Index>(std::make_tuple(std::move(pn)...));
-    }
-    template<class... ParamN>
-    auto operator()(ParamN... pn) const
-        -> typename std::tuple_element<Index, std::tuple<decay_t<ParamN>...>>::type {
-        return                std::get<Index>(std::make_tuple(std::move(pn)...));
+        return                std::get<Index>(std::tie(pn...));
     }
 };
 

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -580,10 +580,17 @@ public:
     {
     }
 
-    maybe(T value)
+    maybe(const T& value)
     : is_set(false)
     {
         new (reinterpret_cast<T*>(&storage)) T(value);
+        is_set = true;
+    }
+
+    maybe(T&& value)
+    : is_set(false)
+    {
+        new (reinterpret_cast<T*>(&storage)) T(std::move(value));
         is_set = true;
     }
 

--- a/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
@@ -197,7 +197,7 @@ subscriber<T, rxt::testable_observer<T>> test_type::test_type_worker::make_subsc
           [ts](T value)
           {
               ts->m.push_back(
-                              recorded_type(ts->sc->clock(), notification_type::on_next(value)));
+                              recorded_type(ts->sc->clock(), notification_type::on_next(std::move(value))));
           },
           // on_error
           [ts](rxu::error_ptr e)
@@ -386,8 +386,8 @@ public:
         messages() {}
 
         template<typename U>
-        static recorded_type next(long ticks, U value) {
-            return recorded_type(ticks, notification_type::on_next(std::move(value)));
+        static recorded_type next(long ticks, U&& value) {
+            return recorded_type(ticks, notification_type::on_next(std::forward<U>(value)));
         }
 
         static recorded_type completed(long ticks) {

--- a/Rx/v2/src/rxcpp/subjects/rx-replaysubject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-replaysubject.hpp
@@ -69,7 +69,7 @@ class replay_observer : public detail::multicast_observer<T>
         {
         }
 
-        void add(T v) const {
+        void add(const T& v) const {
             std::unique_lock<std::mutex> guard(lock);
 
             if (!count.empty()) {
@@ -84,7 +84,7 @@ class replay_observer : public detail::multicast_observer<T>
                 time_points.push_back(now);
             }
 
-            values.push_back(std::move(v));
+            values.push_back(v);
         }
         std::list<T> get() const {
             std::unique_lock<std::mutex> guard(lock);
@@ -115,10 +115,9 @@ public:
         return state->coordinator;
     }
 
-    template<class V>
-    void on_next(V v) const {
+    void on_next(const T& v) const {
         state->add(v);
-        base_type::on_next(std::move(v));
+        base_type::on_next(v);
     }
 };
 

--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -175,7 +175,7 @@ public:
         }
     }
     template<class V>
-    void on_next(V v) const {
+    void on_next(V&& v) const {
         auto current_completer = b->current_completer.lock();
         if (!current_completer) {
             std::unique_lock<std::mutex> guard(b->state->lock);

--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -174,8 +174,7 @@ public:
             std::terminate();
         }
     }
-    template<class V>
-    void on_next(V&& v) const {
+    void on_next(const T& v) const {
         auto current_completer = b->current_completer.lock();
         if (!current_completer) {
             std::unique_lock<std::mutex> guard(b->state->lock);

--- a/Rx/v2/src/rxcpp/subjects/rx-synchronize.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-synchronize.hpp
@@ -72,7 +72,7 @@ class synchronize_observer : public detail::multicast_observer<T>
                         auto notification = std::move(fill_queue.front());
                         fill_queue.pop_front();
                         guard.unlock();
-                        notification->accept(destination);
+                        std::move(*notification).accept(destination);
                         self();
                     } RXCPP_CATCH(...) {
                         destination.on_error(rxu::current_exception());

--- a/Rx/v2/test/copy_verifier.h
+++ b/Rx/v2/test/copy_verifier.h
@@ -41,20 +41,22 @@ public:
     int get_copy_count() const { return _state->copy_count; }
     int get_move_count() const { return _state->move_count; }
 
-    rxcpp::observable<copy_verifier> get_observable()
+    rxcpp::observable<copy_verifier> get_observable(size_t count = 1)
     {
-        return rxcpp::observable<>::create<copy_verifier>([this](rxcpp::subscriber<copy_verifier> sub)
+        return rxcpp::observable<>::create<copy_verifier>([this, count](rxcpp::subscriber<copy_verifier> sub)
         {
-            sub.on_next(*this);
+            for (size_t i =0; i< count; ++i)
+                sub.on_next(*this);
             sub.on_completed();
         });
     }
 
-    rxcpp::observable<copy_verifier> get_observable_for_move()
+    rxcpp::observable<copy_verifier> get_observable_for_move(size_t count = 1)
     {
-        return rxcpp::observable<>::create<copy_verifier>([this](rxcpp::subscriber<copy_verifier> sub)
+        return rxcpp::observable<>::create<copy_verifier>([this, count](rxcpp::subscriber<copy_verifier> sub)
         {
-            sub.on_next(std::move(*this));
+            for (size_t i =0; i< count; ++i)
+                sub.on_next(std::move(*this));
             sub.on_completed();
         });
     }

--- a/Rx/v2/test/copy_verifier.h
+++ b/Rx/v2/test/copy_verifier.h
@@ -58,6 +58,9 @@ public:
             sub.on_completed();
         });
     }
+
+    bool operator==(const copy_verifier&) const { return false; }
+    bool operator!=(const copy_verifier&) const { return true; }
 private:
     struct state
     {

--- a/Rx/v2/test/copy_verifier.h
+++ b/Rx/v2/test/copy_verifier.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <memory>
+
+class copy_verifier
+{
+public:
+    copy_verifier()
+        : _state(std::make_shared<state>()) {}
+
+    copy_verifier(const copy_verifier& other)
+        : _state{other._state}
+    {
+        ++_state->copy_count;
+    }
+
+    copy_verifier(copy_verifier&& other) noexcept
+        : _state{other._state}
+    {
+        ++_state->move_count;
+    }
+
+    copy_verifier& operator=(const copy_verifier& other)
+    {
+        if (this == &other)
+            return *this;
+        _state = other._state;
+        ++_state->copy_count;
+        return *this;
+    }
+
+    copy_verifier& operator=(copy_verifier&& other) noexcept
+    {
+        if (this == &other)
+            return *this;
+        _state = other._state;
+        ++_state->move_count;
+        return *this;
+    }
+
+    int get_copy_count() const { return _state->copy_count; }
+    int get_move_count() const { return _state->move_count; }
+
+    rxcpp::observable<copy_verifier> get_observable()
+    {
+        return rxcpp::observable<>::create<copy_verifier>([this](rxcpp::subscriber<copy_verifier> sub)
+        {
+            sub.on_next(*this);
+            sub.on_completed();
+        });
+    }
+
+    rxcpp::observable<copy_verifier> get_observable_for_move()
+    {
+        return rxcpp::observable<>::create<copy_verifier>([this](rxcpp::subscriber<copy_verifier> sub)
+        {
+            sub.on_next(std::move(*this));
+            sub.on_completed();
+        });
+    }
+private:
+    struct state
+    {
+        int copy_count = 0;
+        int move_count = 0;
+    };
+
+    std::shared_ptr<state> _state;
+};

--- a/Rx/v2/test/operators/all.cpp
+++ b/Rx/v2/test/operators/all.cpp
@@ -1,5 +1,4 @@
 #include "../test.h"
-#include "../copy_verifier.h"
 #include <rxcpp/operators/rx-all.hpp>
 
 

--- a/Rx/v2/test/operators/all.cpp
+++ b/Rx/v2/test/operators/all.cpp
@@ -1,5 +1,7 @@
 #include "../test.h"
+#include "../copy_verifier.h"
 #include <rxcpp/operators/rx-all.hpp>
+
 
 SCENARIO("all emits true if every item emitted by the source observable evaluated as true", "[all][operators]") {
     GIVEN("a source") {
@@ -212,6 +214,47 @@ SCENARIO("all emits an error if the source observable emit an error", "[all][ope
                 REQUIRE(required == actual);
             }
 
+        }
+    }
+}
+
+SCENARIO("all doesn't provide copies", "[all][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().all([](const copy_verifier&) { return true; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("all doesn't provide copies for move", "[all][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().all([](const copy_verifier&) { return true; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
         }
     }
 }

--- a/Rx/v2/test/operators/all.cpp
+++ b/Rx/v2/test/operators/all.cpp
@@ -219,7 +219,7 @@ SCENARIO("all emits an error if the source observable emit an error", "[all][ope
 
 SCENARIO("all doesn't provide copies", "[all][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);
@@ -240,7 +240,7 @@ SCENARIO("all doesn't provide copies", "[all][operators][copies]")
 
 SCENARIO("all doesn't provide copies for move", "[all][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);

--- a/Rx/v2/test/operators/amb.cpp
+++ b/Rx/v2/test/operators/amb.cpp
@@ -954,7 +954,7 @@ SCENARIO("amb never empty, custom coordination", "[amb][join][operators]"){
 
 
 SCENARIO("amb doesn't provide copies", "[amb][join][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -975,7 +975,7 @@ SCENARIO("amb doesn't provide copies", "[amb][join][operators][copies]"){
 
 
 SCENARIO("amb doesn't provide copies for move", "[amb][join][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/amb.cpp
+++ b/Rx/v2/test/operators/amb.cpp
@@ -1,4 +1,5 @@
 #include "../test.h"
+#include "../copy_verifier.h"
 #include "rxcpp/operators/rx-amb.hpp"
 
 SCENARIO("amb never 3", "[amb][join][operators]"){
@@ -951,3 +952,44 @@ SCENARIO("amb never empty, custom coordination", "[amb][join][operators]"){
         }
     }
 }
+
+
+SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(verifier.get_observable()).amb();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("variadic amb doesn't provide copies for move", "[amb][join][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(verifier.get_observable_for_move()).amb();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+

--- a/Rx/v2/test/operators/amb.cpp
+++ b/Rx/v2/test/operators/amb.cpp
@@ -953,10 +953,10 @@ SCENARIO("amb never empty, custom coordination", "[amb][join][operators]"){
 }
 
 
-SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"){
+SCENARIO("amb doesn't provide copies", "[amb][join][operators][copies]"){
     GIVEN("observale and subscriber")
     {
-        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
         copy_verifier verifier{};
         auto          obs = rxcpp::observable<>::just(verifier.get_observable()).amb();
@@ -965,7 +965,8 @@ SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"
             obs.subscribe(sub);
             THEN("no extra copies")
             {
-                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
                 REQUIRE(verifier.get_move_count() == 0);
             }
         }
@@ -973,10 +974,10 @@ SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"
 }
 
 
-SCENARIO("variadic amb doesn't provide copies for move", "[amb][join][operators][copies]"){
+SCENARIO("amb doesn't provide copies for move", "[amb][join][operators][copies]"){
     GIVEN("observale and subscriber")
     {
-        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
         copy_verifier verifier{};
         auto          obs = rxcpp::observable<>::just(verifier.get_observable_for_move()).amb();
@@ -986,7 +987,8 @@ SCENARIO("variadic amb doesn't provide copies for move", "[amb][join][operators]
             THEN("no extra copies")
             {
                 REQUIRE(verifier.get_copy_count() == 0);
-                REQUIRE(verifier.get_move_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
             }
         }
     }

--- a/Rx/v2/test/operators/amb.cpp
+++ b/Rx/v2/test/operators/amb.cpp
@@ -1,5 +1,4 @@
 #include "../test.h"
-#include "../copy_verifier.h"
 #include "rxcpp/operators/rx-amb.hpp"
 
 SCENARIO("amb never 3", "[amb][join][operators]"){

--- a/Rx/v2/test/operators/amb_variadic.cpp
+++ b/Rx/v2/test/operators/amb_variadic.cpp
@@ -592,7 +592,7 @@ SCENARIO("variadic amb never empty, custom coordination", "[amb][join][operators
 SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"){
     GIVEN("observale and subscriber")
     {
-        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
         copy_verifier verifier{};
         auto          obs = verifier.get_observable().amb(rxcpp::observable<>::never<copy_verifier>());
@@ -601,7 +601,8 @@ SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"
             obs.subscribe(sub);
             THEN("no extra copies")
             {
-                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
                 REQUIRE(verifier.get_move_count() == 0);
             }
         }
@@ -612,7 +613,7 @@ SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"
 SCENARIO("variadic amb doesn't provide copies for move", "[amb][join][operators][copies]"){
     GIVEN("observale and subscriber")
     {
-        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
         copy_verifier verifier{};
         auto          obs = verifier.get_observable_for_move().amb(rxcpp::observable<>::never<copy_verifier>());
@@ -622,7 +623,8 @@ SCENARIO("variadic amb doesn't provide copies for move", "[amb][join][operators]
             THEN("no extra copies")
             {
                 REQUIRE(verifier.get_copy_count() == 0);
-                REQUIRE(verifier.get_move_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
             }
         }
     }

--- a/Rx/v2/test/operators/amb_variadic.cpp
+++ b/Rx/v2/test/operators/amb_variadic.cpp
@@ -1,4 +1,5 @@
 #include "../test.h"
+#include "../copy_verifier.h"
 #include "rxcpp/operators/rx-amb.hpp"
 
 SCENARIO("variadic amb never 3", "[amb][join][operators]"){
@@ -584,6 +585,45 @@ SCENARIO("variadic amb never empty, custom coordination", "[amb][join][operators
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().amb(rxcpp::observable<>::never<copy_verifier>());
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("variadic amb doesn't provide copies for move", "[amb][join][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().amb(rxcpp::observable<>::never<copy_verifier>());
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
             }
         }
     }

--- a/Rx/v2/test/operators/amb_variadic.cpp
+++ b/Rx/v2/test/operators/amb_variadic.cpp
@@ -1,5 +1,4 @@
 #include "../test.h"
-#include "../copy_verifier.h"
 #include "rxcpp/operators/rx-amb.hpp"
 
 SCENARIO("variadic amb never 3", "[amb][join][operators]"){

--- a/Rx/v2/test/operators/amb_variadic.cpp
+++ b/Rx/v2/test/operators/amb_variadic.cpp
@@ -590,7 +590,7 @@ SCENARIO("variadic amb never empty, custom coordination", "[amb][join][operators
 }
 
 SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -611,7 +611,7 @@ SCENARIO("variadic amb doesn't provide copies", "[amb][join][operators][copies]"
 
 
 SCENARIO("variadic amb doesn't provide copies for move", "[amb][join][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/any.cpp
+++ b/Rx/v2/test/operators/any.cpp
@@ -212,3 +212,44 @@ SCENARIO("any emits an error", "[any][operators]"){
         }
     }
 }
+
+SCENARIO("any doesn't provide copies", "[any][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().any([](const copy_verifier&) { return true; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("any doesn't provide copies for move", "[any][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().any([](const copy_verifier&) { return true; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/any.cpp
+++ b/Rx/v2/test/operators/any.cpp
@@ -215,7 +215,7 @@ SCENARIO("any emits an error", "[any][operators]"){
 
 SCENARIO("any doesn't provide copies", "[any][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);
@@ -236,7 +236,7 @@ SCENARIO("any doesn't provide copies", "[any][operators][copies]")
 
 SCENARIO("any doesn't provide copies for move", "[any][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);

--- a/Rx/v2/test/operators/buffer.cpp
+++ b/Rx/v2/test/operators/buffer.cpp
@@ -1234,7 +1234,7 @@ SCENARIO("buffer do 1 copy to place object in vector", "[buffer][operators][copi
 {
     GIVEN("observale and subscriber")
     {
-        auto          empty_on_next = [](const std::vector<copy_verifier>&) {};
+        auto          empty_on_next = [](std::vector<copy_verifier>) {};
         auto          sub           = rx::make_observer<std::vector<copy_verifier>>(empty_on_next);
         copy_verifier verifier{};
         auto          obs = verifier.get_observable().buffer(1);
@@ -1254,7 +1254,7 @@ SCENARIO("buffer do 1 copy to place object in vector for move", "[buffer][operat
 {
     GIVEN("observale and subscriber")
     {
-        auto          empty_on_next = [](const std::vector<copy_verifier>&) {};
+        auto          empty_on_next = [](std::vector<copy_verifier>) {};
         auto          sub           = rx::make_observer<std::vector<copy_verifier>>(empty_on_next);
         copy_verifier verifier{};
         auto          obs = verifier.get_observable_for_move().buffer(1);

--- a/Rx/v2/test/operators/buffer.cpp
+++ b/Rx/v2/test/operators/buffer.cpp
@@ -1232,7 +1232,7 @@ SCENARIO("buffer with time or count, only count triggered", "[buffer_with_time_o
 
 SCENARIO("buffer do 1 copy to place object in vector", "[buffer][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](std::vector<copy_verifier>) {};
         auto          sub           = rx::make_observer<std::vector<copy_verifier>>(empty_on_next);
@@ -1252,7 +1252,7 @@ SCENARIO("buffer do 1 copy to place object in vector", "[buffer][operators][copi
 
 SCENARIO("buffer do 1 copy to place object in vector for move", "[buffer][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](std::vector<copy_verifier>) {};
         auto          sub           = rx::make_observer<std::vector<copy_verifier>>(empty_on_next);

--- a/Rx/v2/test/operators/buffer.cpp
+++ b/Rx/v2/test/operators/buffer.cpp
@@ -1229,3 +1229,44 @@ SCENARIO("buffer with time or count, only count triggered", "[buffer_with_time_o
         }
     }
 }
+
+SCENARIO("buffer do 1 copy to place object in vector", "[buffer][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](const std::vector<copy_verifier>&) {};
+        auto          sub           = rx::make_observer<std::vector<copy_verifier>>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().buffer(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("only one copy")
+            {
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("buffer do 1 copy to place object in vector for move", "[buffer][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](const std::vector<copy_verifier>&) {};
+        auto          sub           = rx::make_observer<std::vector<copy_verifier>>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().buffer(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("only one copy")
+            {
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+

--- a/Rx/v2/test/operators/combine_latest.cpp
+++ b/Rx/v2/test/operators/combine_latest.cpp
@@ -1668,7 +1668,7 @@ SCENARIO("combine_latest typical N", "[combine_latest][join][operators]"){
 
 SCENARIO("combine_latest provide 1 copy to store in tuple, 1 copy to send value and 1 move to lambda", "[combine_latest][join][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](const int&) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);
@@ -1695,7 +1695,7 @@ SCENARIO("combine_latest provide 1 copy to store in tuple, 1 copy to send value 
 
 SCENARIO("combine_latest provide 1 move to store in tuple, 1 copy to send value and 1 move to lambda for move", "[combine_latest][join][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](const int&) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);

--- a/Rx/v2/test/operators/concat.cpp
+++ b/Rx/v2/test/operators/concat.cpp
@@ -199,3 +199,46 @@ SCENARIO("concat completes", "[concat][join][operators]"){
         }
     }
 }
+
+SCENARIO("concat doesn't provide copies", "[concat][join][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          root = verifier.get_observable();
+        auto          obs  = root.concat(rxcpp::observable<>::never<copy_verifier>());
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("concat doesn't provide copies for move", "[concat][join][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = []( copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          root = verifier.get_observable_for_move();
+        auto          obs  = root.concat(rxcpp::observable<>::never<copy_verifier>());
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // one move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/concat.cpp
+++ b/Rx/v2/test/operators/concat.cpp
@@ -202,7 +202,7 @@ SCENARIO("concat completes", "[concat][join][operators]"){
 
 SCENARIO("concat doesn't provide copies", "[concat][join][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -224,7 +224,7 @@ SCENARIO("concat doesn't provide copies", "[concat][join][operators][copies]")
 
 SCENARIO("concat doesn't provide copies for move", "[concat][join][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = []( copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/concat.cpp
+++ b/Rx/v2/test/operators/concat.cpp
@@ -204,7 +204,7 @@ SCENARIO("concat doesn't provide copies", "[concat][join][operators][copies]")
 {
     GIVEN("observale and subscriber")
     {
-        auto          empty_on_next = [](const copy_verifier&) {};
+        auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
         copy_verifier verifier{};
         auto          root = verifier.get_observable();
@@ -214,7 +214,8 @@ SCENARIO("concat doesn't provide copies", "[concat][join][operators][copies]")
             obs.subscribe(sub);
             THEN("no extra copies")
             {
-                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
                 REQUIRE(verifier.get_move_count() == 0);
             }
         }

--- a/Rx/v2/test/operators/concat_map.cpp
+++ b/Rx/v2/test/operators/concat_map.cpp
@@ -533,3 +533,46 @@ SCENARIO("concat_transform, no result selector, with coordination", "[concat_tra
         }
     }
 }
+
+SCENARIO("concat_transform do 1 copy to lambda and 1 copy to internal state", "[concat_transform][join][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](int) {};
+        auto          sub           = rx::make_observer<int>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs  = verifier.get_observable().concat_map([](copy_verifier){return rxcpp::observable<>::never<int>();});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to map lambda + 1 copy into internal state
+                REQUIRE(verifier.get_copy_count() == 2);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("concat_transform do 1 copy to lambda and 1 move to internal state for move", "[concat_transform][join][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](int) {};
+        auto          sub           = rx::make_observer<int>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs  = verifier.get_observable_for_move().concat_map([](copy_verifier){return rxcpp::observable<>::never<int>();});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to map lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                // 1 move to internal state
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/concat_map.cpp
+++ b/Rx/v2/test/operators/concat_map.cpp
@@ -536,7 +536,7 @@ SCENARIO("concat_transform, no result selector, with coordination", "[concat_tra
 
 SCENARIO("concat_transform do 1 copy to lambda and 1 copy to internal state", "[concat_transform][join][operators][copies]")
 { 
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);
@@ -557,7 +557,7 @@ SCENARIO("concat_transform do 1 copy to lambda and 1 copy to internal state", "[
 
 SCENARIO("concat_transform do 1 copy to lambda and 1 move to internal state for move", "[concat_transform][join][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);

--- a/Rx/v2/test/operators/concat_map.cpp
+++ b/Rx/v2/test/operators/concat_map.cpp
@@ -535,13 +535,13 @@ SCENARIO("concat_transform, no result selector, with coordination", "[concat_tra
 }
 
 SCENARIO("concat_transform do 1 copy to lambda and 1 copy to internal state", "[concat_transform][join][operators][copies]")
-{
+{ 
     GIVEN("observale and subscriber")
     {
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);
         copy_verifier verifier{};
-        auto          obs  = verifier.get_observable().concat_map([](copy_verifier){return rxcpp::observable<>::never<int>();});
+        auto          obs  = verifier.get_observable().concat_map([](copy_verifier){ return rxcpp::observable<>::never<int>();});
         WHEN("subscribe")
         {
             obs.subscribe(sub);
@@ -562,7 +562,7 @@ SCENARIO("concat_transform do 1 copy to lambda and 1 move to internal state for 
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);
         copy_verifier verifier{};
-        auto          obs  = verifier.get_observable_for_move().concat_map([](copy_verifier){return rxcpp::observable<>::never<int>();});
+        auto          obs  = verifier.get_observable_for_move().concat_map([](copy_verifier){ return rxcpp::observable<>::never<int>();});
         WHEN("subscribe")
         {
             obs.subscribe(sub);

--- a/Rx/v2/test/operators/contains.cpp
+++ b/Rx/v2/test/operators/contains.cpp
@@ -214,7 +214,7 @@ SCENARIO("contains emits an error", "[contains][operators]"){
 
 SCENARIO("contains doesn't provide copies", "[contains][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);
@@ -235,7 +235,7 @@ SCENARIO("contains doesn't provide copies", "[contains][operators][copies]")
 
 SCENARIO("contains doesn't provide copies for move", "[contains][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);
@@ -255,7 +255,7 @@ SCENARIO("contains doesn't provide copies for move", "[contains][operators][copi
 
 SCENARIO("contains provides 1 copy for value to compare", "[contains][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);
@@ -276,7 +276,7 @@ SCENARIO("contains provides 1 copy for value to compare", "[contains][operators]
 
 SCENARIO("contains provides 1 move for value to compare for move", "[contains][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);

--- a/Rx/v2/test/operators/contains.cpp
+++ b/Rx/v2/test/operators/contains.cpp
@@ -211,3 +211,86 @@ SCENARIO("contains emits an error", "[contains][operators]"){
         }
     }
 }
+
+SCENARIO("contains doesn't provide copies", "[contains][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().contains(copy_verifier{});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("contains doesn't provide copies for move", "[contains][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().contains(copy_verifier{});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("contains provides 1 copy for value to compare", "[contains][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        copy_verifier verifier_to_pass{};
+        auto          obs = verifier.get_observable().contains(verifier_to_pass);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier_to_pass.get_copy_count() == 1);
+                REQUIRE(verifier_to_pass.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("contains provides 1 move for value to compare for move", "[contains][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        copy_verifier verifier_to_pass{};
+        auto          obs = verifier.get_observable().contains(std::move(verifier_to_pass));
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier_to_pass.get_copy_count() == 0);
+                REQUIRE(verifier_to_pass.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/default_if_empty.cpp
+++ b/Rx/v2/test/operators/default_if_empty.cpp
@@ -167,7 +167,7 @@ SCENARIO("default_if_empty - source throws", "[default_if_empty][operators]"){
 }
 
 SCENARIO("default_if_empty doesn't provide copies", "[default_if_empty][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -188,7 +188,7 @@ SCENARIO("default_if_empty doesn't provide copies", "[default_if_empty][operator
 
 
 SCENARIO("default_if_empty doesn't provide copies for move", "[default_if_empty][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/default_if_empty.cpp
+++ b/Rx/v2/test/operators/default_if_empty.cpp
@@ -165,3 +165,45 @@ SCENARIO("default_if_empty - source throws", "[default_if_empty][operators]"){
         }
     }
 }
+
+SCENARIO("default_if_empty doesn't provide copies", "[default_if_empty][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().default_if_empty(copy_verifier{});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("default_if_empty doesn't provide copies for move", "[default_if_empty][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().default_if_empty(copy_verifier{});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}
+

--- a/Rx/v2/test/operators/delay.cpp
+++ b/Rx/v2/test/operators/delay.cpp
@@ -164,3 +164,32 @@ SCENARIO("delay - throw", "[delay][operators]"){
         }
     }
 }
+
+SCENARIO("delay provides 1 copy to internal state and 1 move from scheduler", "[delay][operators][copies]")
+{
+    GIVEN("a source")
+    {
+        auto                                      sc = rxsc::make_test();
+        auto                                      so = rx::synchronize_in_one_worker(sc);
+        auto                                      w  = sc.create_worker();
+        const rxsc::test::messages<copy_verifier> on;
+        copy_verifier                             verifier{};
+
+        auto   xs    = sc.make_cold_observable({on.next(150, verifier), on.completed(300)});
+        size_t count = verifier.get_copy_count();
+
+        WHEN("start")
+        {
+            auto res = w.start([so, xs]() { return xs.delay(milliseconds(10), so); });
+
+            THEN("no extra copies")
+            {
+                // 1 copy to internal state
+                CHECK(verifier.get_copy_count() - count == 1);
+                // 1 move from scheduler and 1 move for test_notification
+                REQUIRE(verifier.get_move_count() == 2);
+            }
+        }
+    }
+}
+

--- a/Rx/v2/test/operators/element_at.cpp
+++ b/Rx/v2/test/operators/element_at.cpp
@@ -294,7 +294,7 @@ SCENARIO("element_at - invalid index", "[element_at][operators]"){
 
 
 SCENARIO("element_at doesn't provide copies", "[element_at][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -315,7 +315,7 @@ SCENARIO("element_at doesn't provide copies", "[element_at][operators][copies]")
 
 
 SCENARIO("element_at doesn't provide copies for move", "[element_at][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/element_at.cpp
+++ b/Rx/v2/test/operators/element_at.cpp
@@ -291,3 +291,45 @@ SCENARIO("element_at - invalid index", "[element_at][operators]"){
         }
     }
 }
+
+
+SCENARIO("element_at doesn't provide copies", "[element_at][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().element_at(0);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("element_at doesn't provide copies for move", "[element_at][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().element_at(0);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/exists.cpp
+++ b/Rx/v2/test/operators/exists.cpp
@@ -214,3 +214,25 @@ SCENARIO("exists emits an error", "[exists][operators]"){
         }
     }
 }
+
+
+SCENARIO("exists doesn't provide copies", "[exists][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().exists([](copy_verifier) { return true; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+

--- a/Rx/v2/test/operators/exists.cpp
+++ b/Rx/v2/test/operators/exists.cpp
@@ -217,7 +217,7 @@ SCENARIO("exists emits an error", "[exists][operators]"){
 
 
 SCENARIO("exists doesn't provide copies", "[exists][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);

--- a/Rx/v2/test/operators/filter.cpp
+++ b/Rx/v2/test/operators/filter.cpp
@@ -361,3 +361,45 @@ SCENARIO("filter stops on dispose from predicate", "[where][filter][operators]")
         }
     }
 }
+
+
+SCENARIO("filter doesn't provide copies", "[filter][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().filter([](const copy_verifier&) { return true; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("filter doesn't provide copies for move", "[filter][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().filter([](const copy_verifier&) { return true; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/filter.cpp
+++ b/Rx/v2/test/operators/filter.cpp
@@ -364,7 +364,7 @@ SCENARIO("filter stops on dispose from predicate", "[where][filter][operators]")
 
 
 SCENARIO("filter doesn't provide copies", "[filter][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -385,7 +385,7 @@ SCENARIO("filter doesn't provide copies", "[filter][operators][copies]"){
 
 
 SCENARIO("filter doesn't provide copies for move", "[filter][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/finally.cpp
+++ b/Rx/v2/test/operators/finally.cpp
@@ -198,3 +198,45 @@ SCENARIO("finally - throw", "[finally][operators]"){
         }
     }
 }
+
+
+SCENARIO("finally doesn't provide copies", "[finally][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().finally([]{});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("finally doesn't provide copies for move", "[finally][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().finally([]{});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/finally.cpp
+++ b/Rx/v2/test/operators/finally.cpp
@@ -201,7 +201,7 @@ SCENARIO("finally - throw", "[finally][operators]"){
 
 
 SCENARIO("finally doesn't provide copies", "[finally][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -222,7 +222,7 @@ SCENARIO("finally doesn't provide copies", "[finally][operators][copies]"){
 
 
 SCENARIO("finally doesn't provide copies for move", "[finally][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/flat_map.cpp
+++ b/Rx/v2/test/operators/flat_map.cpp
@@ -789,7 +789,7 @@ SCENARIO("merge_transform, no result selector, with coordination", "[merge_trans
 
 SCENARIO("merge_transform do 1 copy to lambda and 1 copy to internal state", "[merge_transform][transform][operators][copies]")
 { 
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);
@@ -810,7 +810,7 @@ SCENARIO("merge_transform do 1 copy to lambda and 1 copy to internal state", "[m
 
 SCENARIO("merge_transform do 1 copy to lambda and 1 move to internal state for move", "[merge_transform][transform][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);

--- a/Rx/v2/test/operators/group_by.cpp
+++ b/Rx/v2/test/operators/group_by.cpp
@@ -430,3 +430,50 @@ SCENARIO("group_by take 1 take 4", "[group_by][take][operators]"){
         }
     }
 }
+
+SCENARIO("group_by do 1 copy from lambda", "[group_by][operators][copies]")
+{ 
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto obs = verifier.get_observable().group_by([](const auto&) { return true; },
+                                                      [](auto&& v) { return std::forward<decltype(v)>(v); })
+                           .concat();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy from marble lambda + 1 copy to final result (due to subject)
+                REQUIRE(verifier.get_copy_count() == 2);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("group_by do 1 move from lambda and 1 move to internal state for move", "[group_by][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto obs = verifier.get_observable_for_move().group_by([](const auto& ) { return true; },
+                                                               [](auto&& v) { return std::forward<decltype(v)>(v); })
+                           .concat();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final result (due to subject)
+                REQUIRE(verifier.get_copy_count() == 1);
+                // 1 move from lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/group_by.cpp
+++ b/Rx/v2/test/operators/group_by.cpp
@@ -433,7 +433,7 @@ SCENARIO("group_by take 1 take 4", "[group_by][take][operators]"){
 
 SCENARIO("group_by do 1 copy from lambda", "[group_by][operators][copies]")
 { 
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -456,7 +456,7 @@ SCENARIO("group_by do 1 copy from lambda", "[group_by][operators][copies]")
 
 SCENARIO("group_by do 1 move from lambda and 1 move to internal state for move", "[group_by][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/ignore_elements.cpp
+++ b/Rx/v2/test/operators/ignore_elements.cpp
@@ -160,7 +160,7 @@ SCENARIO("ignore_elements - items", "[ignore_elements][operators]"){
 }
 
 SCENARIO("ignore_elements doesn't provide copies", "[ignore_elements][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -180,7 +180,7 @@ SCENARIO("ignore_elements doesn't provide copies", "[ignore_elements][operators]
 
 
 SCENARIO("ignore_elements doesn't provide copies for move", "[ignore_elements][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/ignore_elements.cpp
+++ b/Rx/v2/test/operators/ignore_elements.cpp
@@ -158,3 +158,43 @@ SCENARIO("ignore_elements - items", "[ignore_elements][operators]"){
         }
     }
 }
+
+SCENARIO("ignore_elements doesn't provide copies", "[ignore_elements][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().ignore_elements();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("ignore_elements doesn't provide copies for move", "[ignore_elements][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().ignore_elements();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+

--- a/Rx/v2/test/operators/is_empty.cpp
+++ b/Rx/v2/test/operators/is_empty.cpp
@@ -172,7 +172,7 @@ SCENARIO("is_empty emits an error if the source observable emit an error", "[is_
 
 SCENARIO("is_empty doesn't provide copies", "[is_empty][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);
@@ -193,7 +193,7 @@ SCENARIO("is_empty doesn't provide copies", "[is_empty][operators][copies]")
 
 SCENARIO("is_empty doesn't provide copies for move", "[is_emptyis_empty][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);

--- a/Rx/v2/test/operators/is_empty.cpp
+++ b/Rx/v2/test/operators/is_empty.cpp
@@ -169,3 +169,44 @@ SCENARIO("is_empty emits an error if the source observable emit an error", "[is_
         }
     }
 }
+
+SCENARIO("is_empty doesn't provide copies", "[is_empty][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().is_empty();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("is_empty doesn't provide copies for move", "[is_emptyis_empty][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().is_empty();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/map.cpp
+++ b/Rx/v2/test/operators/map.cpp
@@ -238,3 +238,47 @@ SCENARIO("map - throw", "[map][operators]") {
         }
     }
 }
+
+SCENARIO("map doesn't provide copies", "[map][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().map([](auto&& v) { return std::forward<decltype(v)>(v); });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy from map lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                 // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}
+
+
+SCENARIO("map doesn't provide copies for move", "[map][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().map([](auto&& v) { return std::forward<decltype(v)>(v); });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move from map lambda +  1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 2);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/map.cpp
+++ b/Rx/v2/test/operators/map.cpp
@@ -241,7 +241,7 @@ SCENARIO("map - throw", "[map][operators]") {
 
 SCENARIO("map doesn't provide copies", "[map][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -264,7 +264,7 @@ SCENARIO("map doesn't provide copies", "[map][operators][copies]")
 
 SCENARIO("map doesn't provide copies for move", "[map][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/merge.cpp
+++ b/Rx/v2/test/operators/merge.cpp
@@ -292,3 +292,45 @@ SCENARIO("variadic merge completes", "[merge][join][operators]"){
         }
     }
 }
+
+SCENARIO("merge doesn't provide copies", "[merge][join][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(verifier.get_observable()).merge();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("merge doesn't provide copies for move", "[merge][join][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(verifier.get_observable_for_move()).merge();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}
+

--- a/Rx/v2/test/operators/merge.cpp
+++ b/Rx/v2/test/operators/merge.cpp
@@ -294,7 +294,7 @@ SCENARIO("variadic merge completes", "[merge][join][operators]"){
 }
 
 SCENARIO("merge doesn't provide copies", "[merge][join][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -315,7 +315,7 @@ SCENARIO("merge doesn't provide copies", "[merge][join][operators][copies]"){
 
 
 SCENARIO("merge doesn't provide copies for move", "[merge][join][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/merge_delay_error.cpp
+++ b/Rx/v2/test/operators/merge_delay_error.cpp
@@ -302,3 +302,45 @@ SCENARIO("variadic merge_delay_error completes with 2 errors", "[merge][join][op
         }
     }
 }
+
+
+SCENARIO("merge_delay_error doesn't provide copies", "[merge_delay_error][join][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(verifier.get_observable()).merge_delay_error();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("merge_delay_error doesn't provide copies for move", "[merge_delay_error][join][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(verifier.get_observable_for_move()).merge_delay_error();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/merge_delay_error.cpp
+++ b/Rx/v2/test/operators/merge_delay_error.cpp
@@ -305,7 +305,7 @@ SCENARIO("variadic merge_delay_error completes with 2 errors", "[merge][join][op
 
 
 SCENARIO("merge_delay_error doesn't provide copies", "[merge_delay_error][join][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -326,7 +326,7 @@ SCENARIO("merge_delay_error doesn't provide copies", "[merge_delay_error][join][
 
 
 SCENARIO("merge_delay_error doesn't provide copies for move", "[merge_delay_error][join][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/observe_on.cpp
+++ b/Rx/v2/test/operators/observe_on.cpp
@@ -194,7 +194,7 @@ SCENARIO("observe_on no-comparison", "[observe][observe_on]"){
 
 
 SCENARIO("observe_on doesn't provide copies", "[observe][observe_on][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -216,7 +216,7 @@ SCENARIO("observe_on doesn't provide copies", "[observe][observe_on][operators][
 
 
 SCENARIO("observe_on doesn't provide copies for move", "[observe][observe_on][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/observe_on.cpp
+++ b/Rx/v2/test/operators/observe_on.cpp
@@ -191,3 +191,46 @@ SCENARIO("observe_on no-comparison", "[observe][observe_on]"){
         }
     }
 }
+
+
+SCENARIO("observe_on doesn't provide copies", "[observe][observe_on][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().observe_on(rxcpp::synchronize_new_thread());
+        WHEN("subscribe")
+        {
+            obs.as_blocking().subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to buffer inside
+                REQUIRE(verifier.get_copy_count() == 1);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}
+
+
+SCENARIO("observe_on doesn't provide copies for move", "[observe][observe_on][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().observe_on(rxcpp::synchronize_new_thread());
+        WHEN("subscribe")
+        {
+            obs.as_blocking().subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move  to buffer inside + 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 2);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/on_error_resume_next.cpp
+++ b/Rx/v2/test/operators/on_error_resume_next.cpp
@@ -217,3 +217,53 @@ SCENARIO("on_error_resume_next stops on error", "[on_error_resume_next][operator
         }
     }
 }
+
+
+SCENARIO("on_error_resume_next doesn't provide copies", "[on_error_resume_next][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().on_error_resume_next([](const auto&)
+                                                                           {
+                                                                               return rxcpp::observable<>::empty<copy_verifier>();
+                                                                           });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("on_error_resume_next doesn't provide copies for move", "[on_error_resume_next][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto obs = verifier.get_observable_for_move().on_error_resume_next([](const auto&)
+                                                                           {
+                                                                               return rxcpp::observable<>::empty<copy_verifier>();
+                                                                           });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/on_error_resume_next.cpp
+++ b/Rx/v2/test/operators/on_error_resume_next.cpp
@@ -221,7 +221,7 @@ SCENARIO("on_error_resume_next stops on error", "[on_error_resume_next][operator
 
 SCENARIO("on_error_resume_next doesn't provide copies", "[on_error_resume_next][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -246,7 +246,7 @@ SCENARIO("on_error_resume_next doesn't provide copies", "[on_error_resume_next][
 
 SCENARIO("on_error_resume_next doesn't provide copies for move", "[on_error_resume_next][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/pairwise.cpp
+++ b/Rx/v2/test/operators/pairwise.cpp
@@ -81,7 +81,7 @@ SCENARIO("pairwise - not enough items to create a pair", "[pairwise][operators]"
 
 SCENARIO("pairwise doesn't provide copies", "[pairwise][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](std::tuple<copy_verifier, copy_verifier>) {};
         auto          sub           = rx::make_observer<std::tuple<copy_verifier, copy_verifier>>(empty_on_next);
@@ -104,7 +104,7 @@ SCENARIO("pairwise doesn't provide copies", "[pairwise][operators][copies]")
 
 SCENARIO("pairwise doesn't provide copies for move", "[pairwise][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](std::tuple<copy_verifier, copy_verifier>) {};
         auto          sub           = rx::make_observer<std::tuple<copy_verifier, copy_verifier>>(empty_on_next);

--- a/Rx/v2/test/operators/pairwise.cpp
+++ b/Rx/v2/test/operators/pairwise.cpp
@@ -78,3 +78,49 @@ SCENARIO("pairwise - not enough items to create a pair", "[pairwise][operators]"
         }
     }
 }
+
+SCENARIO("pairwise doesn't provide copies", "[pairwise][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](std::tuple<copy_verifier, copy_verifier>) {};
+        auto          sub           = rx::make_observer<std::tuple<copy_verifier, copy_verifier>>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable(2).pairwise();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to internal state for first, 2 copies for second (one in result, one in internal state)
+                REQUIRE(verifier.get_copy_count() == 3);
+                 // 1 move to final tuple for first, 1 move per object to final lambda
+                REQUIRE(verifier.get_move_count() == 3);
+            }
+        }
+    }
+}
+
+
+SCENARIO("pairwise doesn't provide copies for move", "[pairwise][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](std::tuple<copy_verifier, copy_verifier>) {};
+        auto          sub           = rx::make_observer<std::tuple<copy_verifier, copy_verifier>>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move(2).pairwise();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to tuple for second object
+                REQUIRE(verifier.get_copy_count() == 1);
+                // 1 move to internal state per object, 1 move from state for first + move tuple
+                REQUIRE(verifier.get_move_count() == 5);
+            }
+        }
+    }
+}
+

--- a/Rx/v2/test/operators/reduce.cpp
+++ b/Rx/v2/test/operators/reduce.cpp
@@ -453,3 +453,46 @@ SCENARIO("min, error", "[reduce][min][operators]"){
         }
     }
 }
+
+SCENARIO("reduce doesn't provide copies", "[reduce][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](int) {};
+        auto          sub           = rx::make_observer<int>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().reduce(int{}, [](int seed, copy_verifier) { return seed; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("reduce doesn't provide copies for move", "[reduce][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](int) {};
+        auto          sub           = rx::make_observer<int>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().reduce(int{}, [](int seed, copy_verifier) { return seed; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/reduce.cpp
+++ b/Rx/v2/test/operators/reduce.cpp
@@ -456,7 +456,7 @@ SCENARIO("min, error", "[reduce][min][operators]"){
 
 SCENARIO("reduce doesn't provide copies", "[reduce][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);
@@ -478,7 +478,7 @@ SCENARIO("reduce doesn't provide copies", "[reduce][operators][copies]")
 
 SCENARIO("reduce doesn't provide copies for move", "[reduce][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);

--- a/Rx/v2/test/operators/repeat.cpp
+++ b/Rx/v2/test/operators/repeat.cpp
@@ -386,7 +386,7 @@ SCENARIO("countable repeat, error test", "[repeat][operators]"){
 
 SCENARIO("repeat doesn't provide copies", "[repeat][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -408,7 +408,7 @@ SCENARIO("repeat doesn't provide copies", "[repeat][operators][copies]")
 
 SCENARIO("repeat doesn't provide copies for move", "[repeat][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/repeat.cpp
+++ b/Rx/v2/test/operators/repeat.cpp
@@ -383,3 +383,46 @@ SCENARIO("countable repeat, error test", "[repeat][operators]"){
         }
     }
 }
+
+SCENARIO("repeat doesn't provide copies", "[repeat][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().repeat(2);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda per object
+                REQUIRE(verifier.get_copy_count() == 2);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("repeat doesn't provide copies for move", "[repeat][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().repeat(2);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda per object
+                REQUIRE(verifier.get_move_count() == 2);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/replay.cpp
+++ b/Rx/v2/test/operators/replay.cpp
@@ -699,7 +699,7 @@ SCENARIO("replay multiple subscriptions with count and time", "[replay][multicas
 
 SCENARIO("replay doesn't provide copies", "[replay][multicast][subject][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -721,7 +721,7 @@ SCENARIO("replay doesn't provide copies", "[replay][multicast][subject][operator
 
 SCENARIO("replay doesn't provide copies for move", "[replay][multicast][subject][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/replay.cpp
+++ b/Rx/v2/test/operators/replay.cpp
@@ -696,3 +696,46 @@ SCENARIO("replay multiple subscriptions with count and time", "[replay][multicas
         }
     }
 }
+
+SCENARIO("replay doesn't provide copies", "[replay][multicast][subject][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().replay(1).ref_count();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda + 1 copy to internal state
+                REQUIRE(verifier.get_copy_count() == 2);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("replay doesn't provide copies for move", "[replay][multicast][subject][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().replay(1).ref_count();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda + 1 copy to internal state
+                REQUIRE(verifier.get_copy_count() == 2);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/retry.cpp
+++ b/Rx/v2/test/operators/retry.cpp
@@ -184,7 +184,7 @@ SCENARIO("retry with failure", "[retry][operators]") {
 
 SCENARIO("retry doesn't provide copies", "[retry][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -206,7 +206,7 @@ SCENARIO("retry doesn't provide copies", "[retry][operators][copies]")
 
 SCENARIO("retry doesn't provide copies for move", "[retry][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/retry.cpp
+++ b/Rx/v2/test/operators/retry.cpp
@@ -182,4 +182,45 @@ SCENARIO("retry with failure", "[retry][operators]") {
     }
 }
 
+SCENARIO("retry doesn't provide copies", "[retry][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().retry(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy from map lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
 
+
+SCENARIO("retry doesn't provide copies for move", "[retry][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().retry(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/scan.cpp
+++ b/Rx/v2/test/operators/scan.cpp
@@ -311,7 +311,7 @@ SCENARIO("scan: seed, accumulator throws", "[scan][operators][!throws]"){
 
 SCENARIO("scan doesn't provide copies", "[scan][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);
@@ -333,7 +333,7 @@ SCENARIO("scan doesn't provide copies", "[scan][operators][copies]")
 
 SCENARIO("scan doesn't provide copies for move", "[scan][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](int) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);

--- a/Rx/v2/test/operators/scan.cpp
+++ b/Rx/v2/test/operators/scan.cpp
@@ -308,3 +308,46 @@ SCENARIO("scan: seed, accumulator throws", "[scan][operators][!throws]"){
         }
     }
 }
+
+SCENARIO("scan doesn't provide copies", "[scan][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](int) {};
+        auto          sub           = rx::make_observer<int>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().scan(int{}, [](int seed, copy_verifier) { return seed; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("scan doesn't provide copies for move", "[scan][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](int) {};
+        auto          sub           = rx::make_observer<int>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().scan(int{}, [](int seed, copy_verifier) { return seed; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/sequence_equal.cpp
+++ b/Rx/v2/test/operators/sequence_equal.cpp
@@ -863,7 +863,7 @@ SCENARIO("sequence_equal - both sources emit the same sequence of items, custom 
 
 SCENARIO("sequence_equal doesn't provide copies", "[sequence_equal][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);
@@ -885,7 +885,7 @@ SCENARIO("sequence_equal doesn't provide copies", "[sequence_equal][operators][c
 
 SCENARIO("sequence_equal doesn't provide copies for move", "[sequence_equal][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](bool) {};
         auto          sub           = rx::make_observer<bool>(empty_on_next);

--- a/Rx/v2/test/operators/sequence_equal.cpp
+++ b/Rx/v2/test/operators/sequence_equal.cpp
@@ -860,3 +860,46 @@ SCENARIO("sequence_equal - both sources emit the same sequence of items, custom 
         }
     }
 }
+
+SCENARIO("sequence_equal doesn't provide copies", "[sequence_equal][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().sequence_equal(verifier.get_observable());
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to internal state per object
+                REQUIRE(verifier.get_copy_count() == 2);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("sequence_equal doesn't provide copies for move", "[sequence_equal][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](bool) {};
+        auto          sub           = rx::make_observer<bool>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().sequence_equal(verifier.get_observable_for_move());
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to internal state per object
+                REQUIRE(verifier.get_move_count() == 2);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/skip.cpp
+++ b/Rx/v2/test/operators/skip.cpp
@@ -631,3 +631,44 @@ SCENARIO("skip, consecutive", "[skip][operators]"){
         }
     }
 }
+
+SCENARIO("skip doesn't provide copies", "[skip][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().skip(0);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("skip doesn't provide copies for move", "[skip][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().skip(0);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/skip.cpp
+++ b/Rx/v2/test/operators/skip.cpp
@@ -633,7 +633,7 @@ SCENARIO("skip, consecutive", "[skip][operators]"){
 }
 
 SCENARIO("skip doesn't provide copies", "[skip][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -654,7 +654,7 @@ SCENARIO("skip doesn't provide copies", "[skip][operators][copies]"){
 
 
 SCENARIO("skip doesn't provide copies for move", "[skip][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/skip_last.cpp
+++ b/Rx/v2/test/operators/skip_last.cpp
@@ -277,3 +277,45 @@ SCENARIO("skip_last, source observable emits an error", "[skip_last][operators]"
         }
     }
 }
+
+SCENARIO("skip_last doesn't provide copies", "[skip_last][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable(2).skip_last(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to internal state per object 
+                REQUIRE(verifier.get_copy_count() == 2);
+                // 1 move to final lambda for first
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}
+
+
+SCENARIO("skip_last doesn't provide copies for move", "[skip_last][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move(2).skip_last(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                 // 1 move to internal state per object + 1 move to final lambda for first
+                REQUIRE(verifier.get_move_count() == 3);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/skip_last.cpp
+++ b/Rx/v2/test/operators/skip_last.cpp
@@ -279,7 +279,7 @@ SCENARIO("skip_last, source observable emits an error", "[skip_last][operators]"
 }
 
 SCENARIO("skip_last doesn't provide copies", "[skip_last][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -301,7 +301,7 @@ SCENARIO("skip_last doesn't provide copies", "[skip_last][operators][copies]"){
 
 
 SCENARIO("skip_last doesn't provide copies for move", "[skip_last][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/skip_until.cpp
+++ b/Rx/v2/test/operators/skip_until.cpp
@@ -608,3 +608,44 @@ SCENARIO("skip_until time point, some data next", "[skip_until][skip][operators]
         }
     }
 }
+
+SCENARIO("skip_until doesn't provide copies", "[skip_until][skip][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().skip_until(rxcpp::observable<>::just(1));
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to internal state 
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("skip_until doesn't provide copies for move", "[skip_until][skip][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().skip_until(rxcpp::observable<>::just(1));
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                 // 1 move to internal state
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/skip_until.cpp
+++ b/Rx/v2/test/operators/skip_until.cpp
@@ -610,7 +610,7 @@ SCENARIO("skip_until time point, some data next", "[skip_until][skip][operators]
 }
 
 SCENARIO("skip_until doesn't provide copies", "[skip_until][skip][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -631,7 +631,7 @@ SCENARIO("skip_until doesn't provide copies", "[skip_until][skip][operators][cop
 
 
 SCENARIO("skip_until doesn't provide copies for move", "[skip_until][skip][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/skip_while.cpp
+++ b/Rx/v2/test/operators/skip_while.cpp
@@ -434,7 +434,7 @@ SCENARIO("skip_while, dispose after", "[skip_while][operators]"){
 }
 
 SCENARIO("skip_while doesn't provide copies", "[skip_while][skip][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -455,7 +455,7 @@ SCENARIO("skip_while doesn't provide copies", "[skip_while][skip][operators][cop
 
 
 SCENARIO("skip_while doesn't provide copies for move", "[skip_while][skip][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/skip_while.cpp
+++ b/Rx/v2/test/operators/skip_while.cpp
@@ -432,3 +432,44 @@ SCENARIO("skip_while, dispose after", "[skip_while][operators]"){
         }
     }
 }
+
+SCENARIO("skip_while doesn't provide copies", "[skip_while][skip][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().skip_while([](const auto&) { return false; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to internal state 
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("skip_while doesn't provide copies for move", "[skip_while][skip][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().skip_while([](const auto&) { return false; });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                 // 1 move to internal state
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/switch_on_next.cpp
+++ b/Rx/v2/test/operators/switch_on_next.cpp
@@ -384,7 +384,7 @@ SCENARIO("switch_on_next - inner completes", "[switch_on_next][operators]"){
 }
 
 SCENARIO("switch_on_next doesn't provide copies", "[switch_on_next][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -405,7 +405,7 @@ SCENARIO("switch_on_next doesn't provide copies", "[switch_on_next][operators][c
 
 
 SCENARIO("switch_on_next doesn't provide copies for move", "[switch_on_next][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/switch_on_next.cpp
+++ b/Rx/v2/test/operators/switch_on_next.cpp
@@ -382,3 +382,44 @@ SCENARIO("switch_on_next - inner completes", "[switch_on_next][operators]"){
         }
     }
 }
+
+SCENARIO("switch_on_next doesn't provide copies", "[switch_on_next][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(verifier.get_observable()).switch_on_next();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("switch_on_next doesn't provide copies for move", "[switch_on_next][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(verifier.get_observable_for_move()).switch_on_next();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/take.cpp
+++ b/Rx/v2/test/operators/take.cpp
@@ -617,7 +617,7 @@ SCENARIO("take, dispose after", "[take][operators]"){
 }
 
 SCENARIO("take doesn't provide copies", "[take][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -638,7 +638,7 @@ SCENARIO("take doesn't provide copies", "[take][operators][copies]"){
 
 
 SCENARIO("take doesn't provide copies for move", "[take][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/take.cpp
+++ b/Rx/v2/test/operators/take.cpp
@@ -616,3 +616,43 @@ SCENARIO("take, dispose after", "[take][operators]"){
     }
 }
 
+SCENARIO("take doesn't provide copies", "[take][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().take(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("take doesn't provide copies for move", "[take][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().take(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/take_last.cpp
+++ b/Rx/v2/test/operators/take_last.cpp
@@ -277,7 +277,7 @@ SCENARIO("take_last, source observable emits an error", "[take_last][operators]"
 }
 
 SCENARIO("take_last doesn't provide copies", "[take_last][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -299,7 +299,7 @@ SCENARIO("take_last doesn't provide copies", "[take_last][operators][copies]"){
 
 
 SCENARIO("take_last doesn't provide copies for move", "[take_last][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/take_last.cpp
+++ b/Rx/v2/test/operators/take_last.cpp
@@ -275,3 +275,45 @@ SCENARIO("take_last, source observable emits an error", "[take_last][operators]"
         }
     }
 }
+
+SCENARIO("take_last doesn't provide copies", "[take_last][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().take_last(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to internal state
+                REQUIRE(verifier.get_copy_count() == 1);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}
+
+
+SCENARIO("take_last doesn't provide copies for move", "[take_last][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().take_last(1);
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to internal state + 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 2);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/take_until.cpp
+++ b/Rx/v2/test/operators/take_until.cpp
@@ -794,7 +794,7 @@ SCENARIO("take_until trigger on time point", "[take_until][take][operators]"){
 }
 
 SCENARIO("take_until doesn't provide copies", "[take_until][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -815,7 +815,7 @@ SCENARIO("take_until doesn't provide copies", "[take_until][operators][copies]")
 
 
 SCENARIO("take_until doesn't provide copies for move", "[take_until][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/take_until.cpp
+++ b/Rx/v2/test/operators/take_until.cpp
@@ -792,3 +792,44 @@ SCENARIO("take_until trigger on time point", "[take_until][take][operators]"){
         }
     }
 }
+
+SCENARIO("take_until doesn't provide copies", "[take_until][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().take_until(rxcpp::observable<>::never<bool>());
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("take_until doesn't provide copies for move", "[take_until][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().take_until(rxcpp::observable<>::never<bool>());
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/take_while.cpp
+++ b/Rx/v2/test/operators/take_while.cpp
@@ -548,3 +548,43 @@ SCENARIO("take_while, dispose after", "[take_while][operators]"){
     }
 }
 
+SCENARIO("take_while doesn't provide copies", "[take_while][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().take_while([](const auto&){return true;});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("take_while doesn't provide copies for move", "[take_while][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().take_while([](const auto&){return true;});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                //  1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/take_while.cpp
+++ b/Rx/v2/test/operators/take_while.cpp
@@ -549,7 +549,7 @@ SCENARIO("take_while, dispose after", "[take_while][operators]"){
 }
 
 SCENARIO("take_while doesn't provide copies", "[take_while][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -570,7 +570,7 @@ SCENARIO("take_while doesn't provide copies", "[take_while][operators][copies]")
 
 
 SCENARIO("take_while doesn't provide copies for move", "[take_while][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/tap.cpp
+++ b/Rx/v2/test/operators/tap.cpp
@@ -119,3 +119,44 @@ SCENARIO("tap stops on error", "[tap][operators]"){
         }
     }
 }
+
+SCENARIO("tap doesn't provide copies", "[tap][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().tap([](const auto&){});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("tap doesn't provide copies for move", "[tap][operators][copies]"){
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().tap([](const auto&){});
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                //  1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/tap.cpp
+++ b/Rx/v2/test/operators/tap.cpp
@@ -121,7 +121,7 @@ SCENARIO("tap stops on error", "[tap][operators]"){
 }
 
 SCENARIO("tap doesn't provide copies", "[tap][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -142,7 +142,7 @@ SCENARIO("tap doesn't provide copies", "[tap][operators][copies]"){
 
 
 SCENARIO("tap doesn't provide copies for move", "[tap][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/timestamp.cpp
+++ b/Rx/v2/test/operators/timestamp.cpp
@@ -183,7 +183,7 @@ SCENARIO("should emit timestamped items and an error if there is an error", "[ti
 }
 
 SCENARIO("timestamp doesn't provide copies", "[timestamp][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         typedef rxsc::detail::test_type::clock_type clock_type;
         typedef clock_type::time_point time_point;
@@ -208,7 +208,7 @@ SCENARIO("timestamp doesn't provide copies", "[timestamp][operators][copies]"){
 
 
 SCENARIO("timestamp doesn't provide copies for move", "[timestamp][operators][copies]"){
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         typedef rxsc::detail::test_type::clock_type clock_type;
         typedef clock_type::time_point time_point;

--- a/Rx/v2/test/operators/window.cpp
+++ b/Rx/v2/test/operators/window.cpp
@@ -1044,7 +1044,7 @@ SCENARIO("window with time or count, only count triggered", "[window_with_time_o
 
 SCENARIO("window doesn't provide copies", "[window][operators][copies]")
 { 
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
@@ -1065,7 +1065,7 @@ SCENARIO("window doesn't provide copies", "[window][operators][copies]")
 
 SCENARIO("window doesn't provide copies for move", "[window][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);

--- a/Rx/v2/test/operators/window.cpp
+++ b/Rx/v2/test/operators/window.cpp
@@ -5,6 +5,7 @@
 #include <rxcpp/operators/rx-window.hpp>
 #include <rxcpp/operators/rx-window_time.hpp>
 #include <rxcpp/operators/rx-window_time_count.hpp>
+#include <rxcpp/operators/rx-concat.hpp>
 
 SCENARIO("window count, basic", "[window][operators]"){
     GIVEN("1 hot observable of ints."){
@@ -1036,6 +1037,48 @@ SCENARIO("window with time or count, only count triggered", "[window_with_time_o
                 });
                 auto actual = xs.subscriptions();
                 REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("window doesn't provide copies", "[window][operators][copies]")
+{ 
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto obs = verifier.get_observable().window(1, 1).concat();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("window doesn't provide copies for move", "[window][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto obs = verifier.get_observable_for_move().window(1, 1).concat();
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
             }
         }
     }

--- a/Rx/v2/test/operators/window_toggle.cpp
+++ b/Rx/v2/test/operators/window_toggle.cpp
@@ -318,4 +318,3 @@ SCENARIO("window toggle, disposed", "[window_toggle][operators]"){
         }
     }
 }
-

--- a/Rx/v2/test/operators/with_latest_from.cpp
+++ b/Rx/v2/test/operators/with_latest_from.cpp
@@ -1646,7 +1646,7 @@ SCENARIO("with_latest_from typical N", "[with_latest_from][join][operators]"){
 
 SCENARIO("with_latest_from doesn't provide copies", "[with_latest_from][join][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](const int&) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);
@@ -1668,7 +1668,7 @@ SCENARIO("with_latest_from doesn't provide copies", "[with_latest_from][join][op
 
 SCENARIO("with_latest_from provide doesn't provide copies for move", "[with_latest_from][join][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](const int&) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);

--- a/Rx/v2/test/operators/with_latest_from.cpp
+++ b/Rx/v2/test/operators/with_latest_from.cpp
@@ -1643,3 +1643,47 @@ SCENARIO("with_latest_from typical N", "[with_latest_from][join][operators]"){
         }
     }
 }
+
+SCENARIO("with_latest_from doesn't provide copies", "[with_latest_from][join][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](const int&) {};
+        auto          sub           = rx::make_observer<int>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable().with_latest_from([](copy_verifier, int v) { return v; },
+                                                                       rxcpp::observable<>::just(1));
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 2);
+                // 1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}
+
+SCENARIO("with_latest_from provide doesn't provide copies for move", "[with_latest_from][join][operators][copies]")
+{
+    GIVEN("observale and subscriber")
+    {
+        auto          empty_on_next = [](const int&) {};
+        auto          sub           = rx::make_observer<int>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = verifier.get_observable_for_move().with_latest_from([](copy_verifier, int v) { return v; },
+                                                                                    rxcpp::observable<>::just(1));
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 1);
+                // 1 move to final lambda, 1 move to tuple with cache
+                REQUIRE(verifier.get_move_count() == 2);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/operators/zip.cpp
+++ b/Rx/v2/test/operators/zip.cpp
@@ -1897,7 +1897,7 @@ SCENARIO("zip doesn't provide copies", "[zip][join][operators][copies]")
                 // 1 copy to internal cache
                 REQUIRE(verifier.get_copy_count() == 1);
                 // 1 move from cache + 1 move to tuple + 1 move to lambda
-                REQUIRE(verifier.get_move_count() == 3);
+                REQUIRE(verifier.get_move_count() <= 3);
             }
         }
     }
@@ -1919,7 +1919,7 @@ SCENARIO("zip provide doesn't provide copies for move", "[zip][join][operators][
             {
                 REQUIRE(verifier.get_copy_count() == 0);
                 // 1 move to internal state + 1 move from cache + 1 move to tuple + 1 move to lambda
-                REQUIRE(verifier.get_move_count() == 4);
+                REQUIRE(verifier.get_move_count() <= 4);
             }
         }
     }

--- a/Rx/v2/test/operators/zip.cpp
+++ b/Rx/v2/test/operators/zip.cpp
@@ -1882,7 +1882,7 @@ SCENARIO("zip error after completed right", "[zip][join][operators]"){
 
 SCENARIO("zip doesn't provide copies", "[zip][join][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](const int&) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);
@@ -1905,7 +1905,7 @@ SCENARIO("zip doesn't provide copies", "[zip][join][operators][copies]")
 
 SCENARIO("zip provide doesn't provide copies for move", "[zip][join][operators][copies]")
 {
-    GIVEN("observale and subscriber")
+    GIVEN("observable and subscriber")
     {
         auto          empty_on_next = [](const int&) {};
         auto          sub           = rx::make_observer<int>(empty_on_next);

--- a/Rx/v2/test/subscriptions/observer.cpp
+++ b/Rx/v2/test/subscriptions/observer.cpp
@@ -1,4 +1,5 @@
 #include "../test.h"
+#include "../copy_verifier.h"
 
 SCENARIO("subscriber traits", "[observer][traits]"){
     GIVEN("given some subscriber types"){
@@ -176,6 +177,56 @@ SCENARIO("subscriber behavior", "[observer][traits]"){
                 so.on_completed();
                 REQUIRE(!so.is_subscribed());
             }
+        }
+    }
+}
+
+SCENARIO("observer doesn't provide extra copies", "[observer][copies]"){
+    GIVEN("given some observer types"){
+        auto emptyNext = [](const copy_verifier&){};
+        auto obs = rx::make_observer_dynamic<copy_verifier>(emptyNext);
+        WHEN("send value"){
+            auto verifier = copy_verifier{};
+            obs.on_next(verifier);
+            THEN("no extra copies"){
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+            
+        }
+    }
+}
+
+SCENARIO("subscriber doesn't provide extra copies", "[observer][copies]"){
+    GIVEN("given some observer types"){
+        auto emptyNext = [](const copy_verifier&){};
+        auto obs = rx::make_observer_dynamic<copy_verifier>(emptyNext);
+        auto sub = rx::make_subscriber<copy_verifier>(obs);
+        WHEN("send value"){
+            auto verifier = copy_verifier{};
+            sub.on_next(verifier);
+            THEN("no extra copies"){
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+            
+        }
+    }
+}
+
+SCENARIO("subscriber does only 1 move", "[observer][copies]"){
+    GIVEN("given some observer types"){
+        auto emptyNext = [](copy_verifier){};
+        auto obs = rx::make_observer_dynamic<copy_verifier>(emptyNext);
+        auto sub = rx::make_subscriber<copy_verifier>(obs);
+        WHEN("send value"){
+            auto verifier = copy_verifier{};
+            sub.on_next(std::move(verifier));
+            THEN("no extra copies"){
+                REQUIRE(verifier.get_copy_count() == 0);
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+            
         }
     }
 }

--- a/Rx/v2/test/subscriptions/observer.cpp
+++ b/Rx/v2/test/subscriptions/observer.cpp
@@ -1,5 +1,4 @@
 #include "../test.h"
-#include "../copy_verifier.h"
 
 SCENARIO("subscriber traits", "[observer][traits]"){
     GIVEN("given some subscriber types"){

--- a/Rx/v2/test/test.h
+++ b/Rx/v2/test/test.h
@@ -22,3 +22,5 @@ namespace rxn=rx::notifications;
 namespace rxt = rxcpp::test;
 
 #include "catch.hpp"
+
+#include "copy_verifier.h"

--- a/Rx/v2/test/test.h
+++ b/Rx/v2/test/test.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <exception>
 #if (__GLIBCXX__ / 10000) == 2014 || (__GLIBCXX__ / 10000) == 2015
 namespace std {


### PR DESCRIPTION
Significantly reduce amount of copies/moves inside operators. Each operator checked and fixed.. In most cases via forwarding/universal reference, in some cases via const reference (if operator is read-only). Each fix covered by unit test