### PR TITLE
[WIP] Try to provide ability to use mutable/immutable lambdas dynamically

### DIFF
--- a/Rx/v2/examples/linesfrombytes/main.cpp
+++ b/Rx/v2/examples/linesfrombytes/main.cpp
@@ -53,7 +53,7 @@ int main()
                     }) |
                 as_dynamic();
         }) |
-        tap([](const vector<uint8_t>& v){
+        tap([](vector<uint8_t>& v){
             // print input packet of bytes
             copy(v.begin(), v.end(), ostream_iterator<long>(cout, " "));
             cout << endl;

--- a/Rx/v2/src/rxcpp/rx-notification.hpp
+++ b/Rx/v2/src/rxcpp/rx-notification.hpp
@@ -53,7 +53,7 @@ struct notification_base
 
     virtual void out(std::ostream& out) const =0;
     virtual bool equals(const type& other) const = 0;
-    virtual void accept(const observer_type& o) const & =0;
+    virtual void accept(const observer_type& o) & =0;
     virtual void accept(const observer_type& o) && =0;
 };
 
@@ -140,7 +140,7 @@ private:
                 })));
             return result;
         }
-        void accept(const typename base::observer_type& o) const & override{
+        void accept(const typename base::observer_type& o) & override{
             o.on_next(value);
         }
 
@@ -169,7 +169,7 @@ private:
             })));
             return result;
         }
-        void accept(const typename base::observer_type& o) const & override{
+        void accept(const typename base::observer_type& o) & override{
             o.on_error(ep);
         }
 
@@ -192,7 +192,7 @@ private:
             })));
             return result;
         }
-        void accept(const typename base::observer_type& o) const & override{
+        void accept(const typename base::observer_type& o) & override{
             o.on_completed();
         }
 

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -48,7 +48,11 @@ struct OnNextForward
     OnNextForward() : onnext() {}
     explicit OnNextForward(onnext_t on) : onnext(std::move(on)) {}
     onnext_t onnext;
+
     void operator()(state_t& s, const T& t) const {
+        onnext(s, t);
+    }
+    void operator()(state_t& s, T& t) const {
         onnext(s, t);
     }
     void operator()(state_t& s, T&& t) const {
@@ -61,6 +65,10 @@ struct OnNextForward<T, State, void>
     using state_t = rxu::decay_t<State>;
     OnNextForward() {}
     void operator()(state_t& s, const T& t) const {
+        s.on_next(t);
+    }
+
+    void operator()(state_t& s, T& t) const {
         s.on_next(t);
     }
     void operator()(state_t& s, T&& t) const {
@@ -240,6 +248,10 @@ public:
     void on_next(const T& t) const {
         onnext(state, t);
     }
+
+    void on_next(T& t) const {
+        onnext(state, t);
+    }
     void on_next(T&& t) const {
         onnext(state, std::move(t));
     }
@@ -327,6 +339,10 @@ public:
     void on_next(const T& t) const {
         onnext(t);
     }
+
+    void on_next(T& t) const {
+        onnext(t);
+    }
     void on_next(T&& t) const {
         onnext(std::move(t));
     }
@@ -348,6 +364,7 @@ template<class T>
 struct virtual_observer : public std::enable_shared_from_this<virtual_observer<T>>
 {
     virtual ~virtual_observer() {}
+    virtual void on_next(T&) const {};
     virtual void on_next(const T&) const {};
     virtual void on_next(T&&) const {};
     virtual void on_error(rxu::error_ptr) const {};
@@ -363,6 +380,10 @@ struct specific_observer : public virtual_observer<T>
     }
 
     Observer destination;
+
+    void on_next(T& t) const override {
+        destination.on_next(t);
+    }
     void on_next(const T& t) const override {
         destination.on_next(t);
     }

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -49,30 +49,21 @@ struct OnNextForward
     explicit OnNextForward(onnext_t on) : onnext(std::move(on)) {}
     onnext_t onnext;
 
-    void operator()(state_t& s, const T& t) const {
-        onnext(s, t);
-    }
-    void operator()(state_t& s, T& t) const {
-        onnext(s, t);
-    }
-    void operator()(state_t& s, T&& t) const {
-        onnext(s, std::move(t));
+    template<typename U>
+    void on_next(state_t& s, U&& u) const{
+        onnext(s, std::forward<U>(u));
     }
 };
 template<class T, class State>
 struct OnNextForward<T, State, void>
 {
     using state_t = rxu::decay_t<State>;
-    OnNextForward() {}
-    void operator()(state_t& s, const T& t) const {
-        s.on_next(t);
-    }
+    OnNextForward() = default;
 
-    void operator()(state_t& s, T& t) const {
-        s.on_next(t);
-    }
-    void operator()(state_t& s, T&& t) const {
-        s.on_next(std::move(t));
+    template<typename U>
+    void operator()(state_t& s, U&& u) const
+    {
+        s.on_next(std::forward<U>(u));
     }
 };
 
@@ -245,15 +236,10 @@ public:
         oncompleted = std::move(o.oncompleted);
         return *this;
     }
-    void on_next(const T& t) const {
-        onnext(state, t);
-    }
 
-    void on_next(T& t) const {
-        onnext(state, t);
-    }
-    void on_next(T&& t) const {
-        onnext(state, std::move(t));
+    template<typename U>
+    void on_next(U&& u) const{
+        onnext(state, std::forward<U>(u));
     }
     void on_error(rxu::error_ptr e) const {
         onerror(state, e);
@@ -336,15 +322,9 @@ public:
         oncompleted = std::move(o.oncompleted);
         return *this;
     }
-    void on_next(const T& t) const {
-        onnext(t);
-    }
-
-    void on_next(T& t) const {
-        onnext(t);
-    }
-    void on_next(T&& t) const {
-        onnext(std::move(t));
+    template<typename U>
+    void on_next(U&& u) const{
+        onnext(std::forward<U>(u));
     }
     void on_error(rxu::error_ptr e) const {
         onerror(e);

--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -174,7 +174,9 @@ public:
             std::terminate();
         }
     }
-    void on_next(const T& v) const {
+
+    template<typename U>
+    void on_next(U&& v) const {
         auto current_completer = b->current_completer.lock();
         if (!current_completer) {
             std::unique_lock<std::mutex> guard(b->state->lock);

--- a/Rx/v2/test/operators/map.cpp
+++ b/Rx/v2/test/operators/map.cpp
@@ -282,3 +282,31 @@ SCENARIO("map doesn't provide copies for move", "[map][operators][copies]")
         }
     }
 }
+
+SCENARIO("test mutable", "[map][operators][copies]")
+{
+    // compilable due to all possible on_next calls to map only there
+    auto action  = [](int& v) { return v; };
+    auto sub        = rxcpp::make_subscriber<int>([](const auto&) {});
+    auto new_sub = rxcpp::operators::detail::map<int, decltype(action)>(action)(sub);
+    int  v          = 1;
+    new_sub.on_next(v);
+
+    // non-compilable due to int&& can't be bind to int&
+    // new_sub.on_next(1);
+
+
+    // non-compilable due to virtual_observer has override for const int&, int&& and etc
+    
+    //auto observable = rxcpp::observable<>::just(1).publish();
+    //// subscriber 1
+    //observable.map([](int& v)
+    //{
+    //    v += 2;
+    //    return v;
+    //}).subscribe([](const auto& v) { std::cout << "#1 " << v << std::endl; });
+    //// subscriber 2
+    //observable.subscribe([](const auto& v) { std::cout << "#2 " << v << std::endl; });
+
+    //observable.connect();
+}


### PR DESCRIPTION
To continue thread from #562 .

I've tried to provide override `T&` for on_next. From the point of actual execution it works as expected, but compiler tries to satisfy all possible (and unused) ways of execution (for example, constT& to T&).  Can we solve it?