### PR TITLE
[Perfomance] Significantly reduce amount of copies during source operators

### DIFF
--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -539,14 +539,17 @@ public:
     {
     }
 
-    explicit observable(const source_operator_type& o)
-        : source_operator(o)
-    {
-    }
-    explicit observable(source_operator_type&& o)
-        : source_operator(std::move(o))
-    {
-    }
+    observable(const source_operator_type& o)
+        : source_operator(o) { }
+
+    observable(source_operator_type&& o)
+        : source_operator(std::move(o)) { }
+
+    observable(const observable& o)
+        : source_operator(o.source_operator) {}
+
+    observable(observable&& o)
+        : source_operator(std::move(o.source_operator)) {}
 
     /// implicit conversion between observables of the same value_type
     template<class SO>
@@ -1676,16 +1679,16 @@ public:
     /*! @copydoc rx-iterate.hpp
      */
     template<class Collection>
-    static auto iterate(Collection c)
-        -> decltype(rxs::iterate(std::move(c), identity_current_thread())) {
-        return      rxs::iterate(std::move(c), identity_current_thread());
+    static auto iterate(Collection&& c)
+        -> decltype(rxs::iterate(std::forward<Collection>(c), identity_current_thread())) {
+        return      rxs::iterate(std::forward<Collection>(c), identity_current_thread());
     }
     /*! @copydoc rx-iterate.hpp
      */
     template<class Collection, class Coordination>
-    static auto iterate(Collection c, Coordination cn)
-        -> decltype(rxs::iterate(std::move(c), std::move(cn))) {
-        return      rxs::iterate(std::move(c), std::move(cn));
+    static auto iterate(Collection&& c, Coordination cn)
+        -> decltype(rxs::iterate(std::forward<Collection>(c), std::move(cn))) {
+        return      rxs::iterate(std::forward<Collection>(c), std::move(cn));
     }
 
     /*! @copydoc rxcpp::sources::from()
@@ -1706,41 +1709,41 @@ public:
     /*! @copydoc rxcpp::sources::from(Value0 v0, ValueN... vn)
      */
     template<class Value0, class... ValueN>
-    static auto from(Value0 v0, ValueN... vn)
-        -> typename std::enable_if<!is_coordination<Value0>::value,
-            decltype(   rxs::from(v0, vn...))>::type {
-        return          rxs::from(v0, vn...);
+    static auto from(Value0&& v0, ValueN&&... vn)
+        -> typename std::enable_if<!is_coordination<rxu::decay_t<Value0>>::value,
+            decltype(   rxs::from(std::forward<Value0>(v0), std::forward<ValueN>(vn)...))>::type {
+        return          rxs::from(std::forward<Value0>(v0), std::forward<ValueN>(vn)...);
     }
     /*! @copydoc rxcpp::sources::from(Coordination cn, Value0 v0, ValueN... vn)
      */
     template<class Coordination, class Value0, class... ValueN>
-    static auto from(Coordination cn, Value0 v0, ValueN... vn)
+    static auto from(Coordination cn, Value0&& v0, ValueN&&... vn)
         -> typename std::enable_if<is_coordination<Coordination>::value,
-            decltype(   rxs::from(std::move(cn), v0, vn...))>::type {
-        return          rxs::from(std::move(cn), v0, vn...);
+            decltype(   rxs::from(std::move(cn), std::forward<Value0>(v0), std::forward<ValueN>(vn)...))>::type {
+        return          rxs::from(std::move(cn), std::forward<Value0>(v0), std::forward<ValueN>(vn)...);
     }
 
     /*! @copydoc rxcpp::sources::just(Value0 v0)
      */
     template<class T>
-    static auto just(T v)
-        -> decltype(rxs::just(std::move(v))) {
-        return      rxs::just(std::move(v));
+    static auto just(T&& v)
+        -> decltype(rxs::just(std::forward<T>(v))) {
+        return      rxs::just(std::forward<T>(v));
     }
     /*! @copydoc rxcpp::sources::just(Value0 v0, Coordination cn)
      */
     template<class T, class Coordination>
-    static auto just(T v, Coordination cn)
-        -> decltype(rxs::just(std::move(v), std::move(cn))) {
-        return      rxs::just(std::move(v), std::move(cn));
+    static auto just(T&& v, Coordination cn)
+        -> decltype(rxs::just(std::forward<T>(v), std::move(cn))) {
+        return      rxs::just(std::forward<T>(v), std::move(cn));
     }
 
     /*! @copydoc rxcpp::sources::start_with(Observable o, Value0 v0, ValueN... vn)
      */
     template<class Observable, class Value0, class... ValueN>
-    static auto start_with(Observable o, Value0 v0, ValueN... vn)
-        -> decltype(rxs::start_with(std::move(o), std::move(v0), std::move(vn)...)) {
-        return      rxs::start_with(std::move(o), std::move(v0), std::move(vn)...);
+    static auto start_with(Observable o, Value0&& v0, ValueN&&... vn)
+        -> decltype(rxs::start_with(std::move(o), std::forward<Value0>(v0), std::forward<ValueN>(vn)...)) {
+        return      rxs::start_with(std::move(o), std::forward<Value0>(v0), std::forward<ValueN>(vn)...);
     }
 
     /*! @copydoc rx-empty.hpp

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -539,17 +539,14 @@ public:
     {
     }
 
-    observable(const source_operator_type& o)
-        : source_operator(o) { }
-
-    observable(source_operator_type&& o)
-        : source_operator(std::move(o)) { }
-
-    observable(const observable& o)
-        : source_operator(o.source_operator) {}
-
-    observable(observable&& o)
-        : source_operator(std::move(o.source_operator)) {}
+    explicit observable(const source_operator_type& o)
+        : source_operator(o)
+    {
+    }
+    explicit observable(source_operator_type&& o)
+        : source_operator(std::move(o))
+    {
+    }
 
     /// implicit conversion between observables of the same value_type
     template<class SO>

--- a/Rx/v2/test/CMakeLists.txt
+++ b/Rx/v2/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_SOURCES
     ${TEST_DIR}/sources/defer.cpp
     ${TEST_DIR}/sources/empty.cpp
     ${TEST_DIR}/sources/interval.cpp
+    ${TEST_DIR}/sources/iterate.cpp
     ${TEST_DIR}/sources/scope.cpp
     ${TEST_DIR}/sources/timer.cpp
     ${TEST_DIR}/operators/all.cpp

--- a/Rx/v2/test/sources/create.cpp
+++ b/Rx/v2/test/sources/create.cpp
@@ -82,3 +82,56 @@ SCENARIO("when observer::on_next is overridden", "[create][observer][sources]"){
         }
     }
 }
+
+
+SCENARIO("create doesn't provide copies", "[create][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::create<copy_verifier>([&verifier](rxcpp::subscriber<copy_verifier> sub)
+        {
+            sub.on_next(verifier);
+            sub.on_completed();
+        });
+
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("create doesn't provide copies for move", "[create][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::create<copy_verifier>([&verifier](rxcpp::subscriber<copy_verifier> sub)
+        {
+            sub.on_next(std::move(verifier));
+            sub.on_completed();
+        });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                //  1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/sources/defer.cpp
+++ b/Rx/v2/test/sources/defer.cpp
@@ -57,3 +57,61 @@ SCENARIO("defer stops on completion", "[defer][sources]"){
         }
     }
 }
+
+SCENARIO("defer doesn't provide copies", "[defer][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::defer([&verifier]()
+        {
+            return rxcpp::observable<>::create<copy_verifier>([&verifier](rxcpp::subscriber<copy_verifier> sub)
+            {
+                sub.on_next(verifier);
+                sub.on_completed();
+            });;
+        });
+
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                REQUIRE(verifier.get_copy_count() == 1);
+                REQUIRE(verifier.get_move_count() == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("defer doesn't provide copies for move", "[defer][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::defer([&verifier]()
+        {
+            return rxcpp::observable<>::create<copy_verifier>([&verifier](rxcpp::subscriber<copy_verifier> sub)
+            {
+                sub.on_next(std::move(verifier));
+                sub.on_completed();
+            });;
+        });
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                REQUIRE(verifier.get_copy_count() == 0);
+                //  1 move to final lambda
+                REQUIRE(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/sources/iterate.cpp
+++ b/Rx/v2/test/sources/iterate.cpp
@@ -1,0 +1,143 @@
+#include "../test.h"
+
+SCENARIO("just doesn't provide copies", "[just][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(verifier);
+
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to collection  + 1 copy to final lambda
+                CHECK(verifier.get_copy_count() == 2);
+                // 1 move to internal state
+                CHECK(verifier.get_move_count() == 1);
+            }
+        }
+    }
+}
+
+
+SCENARIO("just doesn't provide copies for move", "[just][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::just(std::move(verifier));;
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                CHECK(verifier.get_copy_count() == 1);
+                // 1 move to internal state +  1 move to internal state
+                CHECK(verifier.get_move_count() == 2);
+            }
+        }
+    }
+}
+
+SCENARIO("from variadic doesn't provide copies", "[from][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::from(verifier, verifier, verifier);
+
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to collection  + 1 copy to final lambda
+                CHECK(verifier.get_copy_count() == 3*2);
+                // 1 move to internal state
+                CHECK(verifier.get_move_count() == 3*1);
+            }
+        }
+    }
+}
+
+
+SCENARIO("from variadic doesn't provide copies for move", "[from][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        auto          obs = rxcpp::observable<>::from(std::move(verifier), std::move(verifier), std::move(verifier));;
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to final lambda
+                CHECK(verifier.get_copy_count() == 3*1);
+                // 1 move to collection + 1 move to internal state
+                CHECK(verifier.get_move_count() == 3*2);
+            }
+        }
+    }
+}
+
+SCENARIO("iterate doesn't provide copies", "[iterate][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+        std::vector<copy_verifier> vec{verifier};
+        int                        initial_copies = verifier.get_copy_count();
+        int                        initial_moves  = verifier.get_move_count();
+        auto                       obs            = rxcpp::observable<>::iterate(vec);
+
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                // 1 copy to internal state + 1 copy to final lambda
+                CHECK(verifier.get_copy_count() - initial_copies == 2);
+                CHECK(verifier.get_move_count() - initial_moves  == 0);
+            }
+        }
+    }
+}
+
+
+SCENARIO("iterate doesn't provide copies for move", "[iterate][sources][copies]")
+{
+    GIVEN("observable and subscriber")
+    {
+        auto          empty_on_next = [](copy_verifier) {};
+        auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
+        copy_verifier verifier{};
+         std::vector<copy_verifier> vec{std::move(verifier)};
+        int                        initial_copies = verifier.get_copy_count();
+        int                        initial_moves = verifier.get_move_count();
+        auto          obs = rxcpp::observable<>::iterate(std::move(vec));
+        WHEN("subscribe")
+        {
+            obs.subscribe(sub);
+            THEN("no extra copies")
+            {
+                //  1 copy to final lambda
+                CHECK(verifier.get_copy_count() - initial_copies == 1);
+                CHECK(verifier.get_move_count() - initial_moves == 0);
+            }
+        }
+    }
+}

--- a/Rx/v2/test/sources/iterate.cpp
+++ b/Rx/v2/test/sources/iterate.cpp
@@ -39,7 +39,7 @@ SCENARIO("just doesn't provide copies for move", "[just][sources][copies]")
             {
                 // 1 copy to final lambda
                 CHECK(verifier.get_copy_count() == 1);
-                // 1 move to internal state +  1 move to internal state
+                // 1 move to collection  +  1 move to internal state
                 CHECK(verifier.get_move_count() == 2);
             }
         }
@@ -125,7 +125,7 @@ SCENARIO("iterate doesn't provide copies for move", "[iterate][sources][copies]"
         auto          empty_on_next = [](copy_verifier) {};
         auto          sub           = rx::make_observer<copy_verifier>(empty_on_next);
         copy_verifier verifier{};
-         std::vector<copy_verifier> vec{std::move(verifier)};
+        std::vector<copy_verifier> vec{std::move(verifier)};
         int                        initial_copies = verifier.get_copy_count();
         int                        initial_moves = verifier.get_move_count();
         auto          obs = rxcpp::observable<>::iterate(std::move(vec));


### PR DESCRIPTION
Reduce amount of copies in source operators. Especially for iterate/just/from: reduce from 12-15 copies + 5-6 moves per object + till 2-3 copies OR moves