### PR TITLE
replace C-style pointer cast type deduction by 'std::declval<>()'

### DIFF
--- a/.github/workflows/rxcpp-ci.yml
+++ b/.github/workflows/rxcpp-ci.yml
@@ -77,7 +77,7 @@ jobs:
             os: windows-latest,
             build_type: Debug,
             cc: "cl", cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=17",
             experimental: true
           }
@@ -86,7 +86,7 @@ jobs:
             os: windows-latest,
             build_type: RelWithDebInfo,
             cc: "cl", cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cmake_args: "-D CMAKE_CXX_STANDARD:STRING=17",
             experimental: true
           }

--- a/Rx/v2/src/rxcpp/operators/rx-all.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-all.hpp
@@ -42,11 +42,11 @@ using all_invalid_t = typename all_invalid<AN...>::type;
 template<class T, class Predicate>
 struct all
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Predicate> test_type;
+    using source_value_type = rxu::decay_t<T>;
+    using test_type = rxu::decay_t<Predicate>;
     test_type test;
 
-    typedef bool value_type;
+    using value_type = bool;
 
     all(test_type t)
         : test(std::move(t))
@@ -56,10 +56,10 @@ struct all
     template<class Subscriber>
     struct all_observer
     {
-        typedef all_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = all_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         test_type test;
         mutable bool done;

--- a/Rx/v2/src/rxcpp/operators/rx-amb.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-amb.hpp
@@ -64,16 +64,16 @@ struct amb
     //static_assert(is_observable<Observable>::value, "amb requires an observable");
     //static_assert(is_observable<T>::value, "amb requires an observable that contains observables");
 
-    typedef amb<T, Observable, Coordination> this_type;
+    using this_type = amb<T, Observable, Coordination>;
 
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Observable> source_type;
+    using source_value_type = rxu::decay_t<T>;
+    using source_type = rxu::decay_t<Observable>;
 
-    typedef typename source_type::source_operator_type source_operator_type;
-    typedef typename source_value_type::value_type value_type;
+    using source_operator_type = typename source_type::source_operator_type;
+    using value_type = typename source_value_type::value_type;
 
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct values
     {
@@ -96,7 +96,7 @@ struct amb
     void on_subscribe(Subscriber scbr) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct amb_state_type
             : public std::enable_shared_from_this<amb_state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-any.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-any.hpp
@@ -50,9 +50,9 @@ using any_invalid_t = typename any_invalid<AN...>::type;
 template<class T, class Predicate>
 struct any
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef bool value_type;
-    typedef rxu::decay_t<Predicate> test_type;
+    using source_value_type = rxu::decay_t<T>;
+    using value_type = bool;
+    using test_type = rxu::decay_t<Predicate>;
     test_type test;
 
     any(test_type t)
@@ -63,10 +63,10 @@ struct any
     template<class Subscriber>
     struct any_observer
     {
-        typedef any_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = any_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         test_type test;
         mutable bool done;

--- a/Rx/v2/src/rxcpp/operators/rx-buffer_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-buffer_count.hpp
@@ -46,8 +46,8 @@ using buffer_count_invalid_t = typename buffer_count_invalid<AN...>::type;
 template<class T>
 struct buffer_count
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef std::vector<source_value_type> value_type;
+    using source_value_type = rxu::decay_t<T>;
+    using value_type = std::vector<source_value_type>;
 
     struct buffer_count_values
     {
@@ -70,10 +70,10 @@ struct buffer_count
     template<class Subscriber>
     struct buffer_count_observer : public buffer_count_values
     {
-        typedef buffer_count_observer<Subscriber> this_type;
-        typedef std::vector<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = buffer_count_observer<Subscriber>;
+        using value_type = std::vector<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         mutable int cursor;
         mutable std::deque<value_type> chunks;

--- a/Rx/v2/src/rxcpp/operators/rx-buffer_time.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-buffer_time.hpp
@@ -66,11 +66,11 @@ using buffer_with_time_invalid_t = typename buffer_with_time_invalid<AN...>::typ
 template<class T, class Duration, class Coordination>
 struct buffer_with_time
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef std::vector<source_value_type> value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
-    typedef rxu::decay_t<Duration> duration_type;
+    using source_value_type = rxu::decay_t<T>;
+    using value_type = std::vector<source_value_type>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
+    using duration_type = rxu::decay_t<Duration>;
 
     struct buffer_with_time_values
     {
@@ -94,10 +94,10 @@ struct buffer_with_time
     template<class Subscriber>
     struct buffer_with_time_observer
     {
-        typedef buffer_with_time_observer<Subscriber> this_type;
-        typedef std::vector<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = buffer_with_time_observer<Subscriber>;
+        using value_type = std::vector<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
 
         struct buffer_with_time_subscriber_values : public buffer_with_time_values
         {

--- a/Rx/v2/src/rxcpp/operators/rx-buffer_time_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-buffer_time_count.hpp
@@ -48,11 +48,11 @@ using buffer_with_time_or_count_invalid_t = typename buffer_with_time_or_count_i
 template<class T, class Duration, class Coordination>
 struct buffer_with_time_or_count
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef std::vector<source_value_type> value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
-    typedef rxu::decay_t<Duration> duration_type;
+    using source_value_type = rxu::decay_t<T>;
+    using value_type = std::vector<source_value_type>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
+    using duration_type = rxu::decay_t<Duration>;
 
     struct buffer_with_time_or_count_values
     {
@@ -76,10 +76,10 @@ struct buffer_with_time_or_count
     template<class Subscriber>
     struct buffer_with_time_or_count_observer
     {
-        typedef buffer_with_time_or_count_observer<Subscriber> this_type;
-        typedef std::vector<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = buffer_with_time_or_count_observer<Subscriber>;
+        using value_type = std::vector<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
 
         struct buffer_with_time_or_count_subscriber_values : public buffer_with_time_or_count_values
         {
@@ -99,7 +99,8 @@ struct buffer_with_time_or_count
             mutable int chunk_id;
             mutable value_type chunk;
         };
-        typedef std::shared_ptr<buffer_with_time_or_count_subscriber_values> state_type;
+
+        using state_type = std::shared_ptr<buffer_with_time_or_count_subscriber_values>;
         state_type state;
 
         buffer_with_time_or_count_observer(composite_subscription cs, dest_type d, buffer_with_time_or_count_values v, coordinator_type c)

--- a/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
@@ -77,10 +77,10 @@ struct invalid_combine_latest_selector {
 };
 
 template<class Selector, class... ObservableN>
-struct is_combine_latest_selector : public std::conditional<
+struct is_combine_latest_selector : public std::conditional_t<
     is_combine_latest_selector_check<Selector, ObservableN...>::value, 
     is_combine_latest_selector_check<Selector, ObservableN...>, 
-    invalid_combine_latest_selector<Selector, ObservableN...>>::type {
+    invalid_combine_latest_selector<Selector, ObservableN...>> {
 };
 
 template<class Selector, class... ON>

--- a/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
@@ -68,7 +68,7 @@ struct is_combine_latest_selector_check {
 
     using type = decltype(check<selector_type, rxu::decay_t<ObservableN>...>(0));
 
-    static const bool value = !std::is_same<type, tag_not_valid>::value;
+    static const bool value = !std::is_same_v<type, tag_not_valid>;
 };
 
 template<class Selector, class... ObservableN>

--- a/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
@@ -62,7 +62,7 @@ struct is_combine_latest_selector_check {
 
     struct tag_not_valid;
     template<class CS, class... CON>
-    static auto check(int) -> decltype((*(CS*)nullptr)((*(typename CON::value_type*)nullptr)...));
+    static auto check(int) -> decltype(std::declval<CS>()((std::declval<typename CON::value_type>())...));
     template<class CS, class... CON>
     static tag_not_valid check(...);
 

--- a/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
@@ -58,7 +58,7 @@ using combine_latest_invalid_t = typename combine_latest_invalid<AN...>::type;
 
 template<class Selector, class... ObservableN>
 struct is_combine_latest_selector_check {
-    typedef rxu::decay_t<Selector> selector_type;
+    using selector_type = rxu::decay_t<Selector>;
 
     struct tag_not_valid;
     template<class CS, class... CON>
@@ -89,29 +89,29 @@ using result_combine_latest_selector_t = typename is_combine_latest_selector<Sel
 template<class Coordination, class Selector, class... ObservableN>
 struct combine_latest_traits {
 
-    typedef std::tuple<ObservableN...> tuple_source_type;
-    typedef std::tuple<rxu::detail::maybe<typename ObservableN::value_type>...> tuple_source_value_type;
+    using tuple_source_type = std::tuple<ObservableN...>;
+    using tuple_source_value_type = std::tuple<rxu::detail::maybe < typename ObservableN::value_type>...>;
 
-    typedef rxu::decay_t<Selector> selector_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
+    using selector_type = rxu::decay_t<Selector>;
+    using coordination_type = rxu::decay_t<Coordination>;
 
-    typedef typename is_combine_latest_selector<selector_type, ObservableN...>::type value_type;
+    using value_type = typename is_combine_latest_selector<selector_type, ObservableN...>::type;
 };
 
 template<class Coordination, class Selector, class... ObservableN>
 struct combine_latest : public operator_base<rxu::value_type_t<combine_latest_traits<Coordination, Selector, ObservableN...>>>
 {
-    typedef combine_latest<Coordination, Selector, ObservableN...> this_type;
+    using this_type = combine_latest<Coordination, Selector, ObservableN...>;
 
-    typedef combine_latest_traits<Coordination, Selector, ObservableN...> traits;
+    using traits = combine_latest_traits<Coordination, Selector, ObservableN...>;
 
-    typedef typename traits::tuple_source_type tuple_source_type;
-    typedef typename traits::tuple_source_value_type tuple_source_value_type;
+    using tuple_source_type = typename traits::tuple_source_type;
+    using tuple_source_value_type = typename traits::tuple_source_value_type;
 
-    typedef typename traits::selector_type selector_type;
+    using selector_type = typename traits::selector_type;
 
-    typedef typename traits::coordination_type coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = typename traits::coordination_type;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct values
     {
@@ -135,7 +135,7 @@ struct combine_latest : public operator_base<rxu::value_type_t<combine_latest_tr
     template<int Index, class State>
     void subscribe_one(std::shared_ptr<State> state) const {
 
-        typedef typename std::tuple_element<Index, tuple_source_type>::type::value_type source_value_type;
+        using source_value_type = typename std::tuple_element<Index, tuple_source_type>::type::value_type;
 
         composite_subscription innercs;
 
@@ -200,7 +200,7 @@ struct combine_latest : public operator_base<rxu::value_type_t<combine_latest_tr
     void on_subscribe(Subscriber scbr) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct combine_latest_state_type
             : public std::enable_shared_from_this<combine_latest_state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-concat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat.hpp
@@ -63,17 +63,17 @@ template<class T, class Observable, class Coordination>
 struct concat
     : public operator_base<rxu::value_type_t<rxu::decay_t<T>>>
 {
-    typedef concat<T, Observable, Coordination> this_type;
+    using this_type = concat<T, Observable, Coordination>;
 
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
+    using source_value_type = rxu::decay_t<T>;
+    using source_type = rxu::decay_t<Observable>;
+    using coordination_type = rxu::decay_t<Coordination>;
 
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
-    typedef typename source_type::source_operator_type source_operator_type;
-    typedef source_value_type collection_type;
-    typedef typename collection_type::value_type value_type;
+    using source_operator_type = typename source_type::source_operator_type;
+    using collection_type = source_value_type;
+    using value_type = typename collection_type::value_type;
 
     struct values
     {
@@ -96,7 +96,7 @@ struct concat
     void on_subscribe(Subscriber scbr) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct concat_state_type
             : public std::enable_shared_from_this<concat_state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
@@ -64,7 +64,7 @@ struct concat_traits {
     template<class CV, class CCS>
     static tag_not_valid collection_check(...);
 
-    static_assert(!std::is_same<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>::value, "concat_map CollectionSelector must be a function with the signature observable(concat_map::source_value_type)");
+    static_assert(!std::is_same_v<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>, "concat_map CollectionSelector must be a function with the signature observable(concat_map::source_value_type)");
 
     using collection_type = decltype(std::declval<collection_selector_type>()((*(source_value_type *) nullptr)));
 
@@ -79,7 +79,7 @@ struct concat_traits {
     template<class CV, class CCV, class CRS>
     static tag_not_valid result_check(...);
 
-    static_assert(!std::is_same<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>::value, "concat_map ResultSelector must be a function with the signature concat_map::value_type(concat_map::source_value_type, concat_map::collection_value_type)");
+    static_assert(!std::is_same_v<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>, "concat_map ResultSelector must be a function with the signature concat_map::value_type(concat_map::source_value_type, concat_map::collection_value_type)");
 
     using value_type = rxu::decay_t<decltype(std::declval<result_selector_type>()(std::declval<source_value_type>(), std::declval<collection_value_type>()))> ;
 };

--- a/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
@@ -60,13 +60,13 @@ struct concat_traits {
 
     struct tag_not_valid {};
     template<class CV, class CCS>
-    static auto collection_check(int) -> decltype((*(CCS*)nullptr)(*(CV*)nullptr));
+    static auto collection_check(int) -> decltype(std::declval<CCS>()(std::declval<CV>()));
     template<class CV, class CCS>
     static tag_not_valid collection_check(...);
 
     static_assert(!std::is_same<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>::value, "concat_map CollectionSelector must be a function with the signature observable(concat_map::source_value_type)");
 
-    typedef decltype((*(collection_selector_type*)nullptr)((*(source_value_type*)nullptr))) collection_type;
+    using collection_type = decltype(std::declval<collection_selector_type>()((*(source_value_type *) nullptr)));
 
 //#if _MSC_VER >= 1900
     static_assert(is_observable<collection_type>::value, "concat_map CollectionSelector must return an observable");
@@ -75,13 +75,13 @@ struct concat_traits {
     typedef typename collection_type::value_type collection_value_type;
 
     template<class CV, class CCV, class CRS>
-    static auto result_check(int) -> decltype((*(CRS*)nullptr)(*(CV*)nullptr, *(CCV*)nullptr));
+    static auto result_check(int) -> decltype((std::declval<CRS>())(std::declval<CV>(), std::declval<CCV>()));
     template<class CV, class CCV, class CRS>
     static tag_not_valid result_check(...);
 
     static_assert(!std::is_same<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>::value, "concat_map ResultSelector must be a function with the signature concat_map::value_type(concat_map::source_value_type, concat_map::collection_value_type)");
 
-    typedef rxu::decay_t<decltype((*(result_selector_type*)nullptr)(*(source_value_type*)nullptr, *(collection_value_type*)nullptr))> value_type;
+    using value_type = rxu::decay_t<decltype(std::declval<result_selector_type>()(std::declval<source_value_type>(), std::declval<collection_value_type>()))> ;
 };
 
 template<class Observable, class CollectionSelector, class ResultSelector, class Coordination>

--- a/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
@@ -51,12 +51,12 @@ using concat_map_invalid_t = typename concat_map_invalid<AN...>::type;
 
 template<class Observable, class CollectionSelector, class ResultSelector, class Coordination>
 struct concat_traits {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<CollectionSelector> collection_selector_type;
-    typedef rxu::decay_t<ResultSelector> result_selector_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
+    using source_type = rxu::decay_t<Observable>;
+    using collection_selector_type = rxu::decay_t<CollectionSelector>;
+    using result_selector_type = rxu::decay_t<ResultSelector>;
+    using coordination_type = rxu::decay_t<Coordination>;
 
-    typedef typename source_type::value_type source_value_type;
+    using source_value_type = typename source_type::value_type;
 
     struct tag_not_valid {};
     template<class CV, class CCS>
@@ -72,7 +72,7 @@ struct concat_traits {
     static_assert(is_observable<collection_type>::value, "concat_map CollectionSelector must return an observable");
 //#endif
 
-    typedef typename collection_type::value_type collection_value_type;
+    using collection_value_type = typename collection_type::value_type;
 
     template<class CV, class CCV, class CRS>
     static auto result_check(int) -> decltype((std::declval<CRS>())(std::declval<CV>(), std::declval<CCV>()));
@@ -88,19 +88,19 @@ template<class Observable, class CollectionSelector, class ResultSelector, class
 struct concat_map
     : public operator_base<rxu::value_type_t<concat_traits<Observable, CollectionSelector, ResultSelector, Coordination>>>
 {
-    typedef concat_map<Observable, CollectionSelector, ResultSelector, Coordination> this_type;
-    typedef concat_traits<Observable, CollectionSelector, ResultSelector, Coordination> traits;
+    using this_type = concat_map<Observable, CollectionSelector, ResultSelector, Coordination>;
+    using traits = concat_traits<Observable, CollectionSelector, ResultSelector, Coordination>;
 
-    typedef typename traits::source_type source_type;
-    typedef typename traits::collection_selector_type collection_selector_type;
-    typedef typename traits::result_selector_type result_selector_type;
+    using source_type = typename traits::source_type;
+    using collection_selector_type = typename traits::collection_selector_type;
+    using result_selector_type = typename traits::result_selector_type;
 
-    typedef typename traits::source_value_type source_value_type;
-    typedef typename traits::collection_type collection_type;
-    typedef typename traits::collection_value_type collection_value_type;
+    using source_value_type = typename traits::source_value_type;
+    using collection_type = typename traits::collection_type;
+    using collection_value_type = typename traits::collection_value_type;
 
-    typedef typename traits::coordination_type coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = typename traits::coordination_type;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct values
     {
@@ -129,7 +129,7 @@ struct concat_map
     void on_subscribe(Subscriber scbr) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct concat_map_state_type
             : public std::enable_shared_from_this<concat_map_state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-connect_forever.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-connect_forever.hpp
@@ -34,7 +34,7 @@ using connect_forever_invalid_t = typename connect_forever_invalid<AN...>::type;
 template<class T, class ConnectableObservable>
 struct connect_forever : public operator_base<T>
 {
-    typedef rxu::decay_t<ConnectableObservable> source_type;
+    using source_type = rxu::decay_t<ConnectableObservable>;
 
     source_type source;
 

--- a/Rx/v2/src/rxcpp/operators/rx-debounce.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-debounce.hpp
@@ -43,10 +43,10 @@ using debounce_invalid_t = typename debounce_invalid<AN...>::type;
 template<class T, class Duration, class Coordination>
 struct debounce
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
-    typedef rxu::decay_t<Duration> duration_type;
+    using source_value_type = rxu::decay_t<T>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
+    using duration_type = rxu::decay_t<Duration>;
 
     struct debounce_values
     {
@@ -69,10 +69,10 @@ struct debounce
     template<class Subscriber>
     struct debounce_observer
     {
-        typedef debounce_observer<Subscriber> this_type;
-        typedef rxu::decay_t<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using this_type = debounce_observer<Subscriber>;
+        using value_type = rxu::decay_t<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
 
         struct debounce_subscriber_values : public debounce_values
         {
@@ -93,7 +93,8 @@ struct debounce
             mutable std::size_t index;
             mutable rxu::maybe<value_type> value;
         };
-        typedef std::shared_ptr<debounce_subscriber_values> state_type;
+
+        using state_type = std::shared_ptr<debounce_subscriber_values>;
         state_type state;
 
         debounce_observer(composite_subscription cs, dest_type d, debounce_values v, coordinator_type c)

--- a/Rx/v2/src/rxcpp/operators/rx-delay.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-delay.hpp
@@ -43,10 +43,10 @@ using delay_invalid_t = typename delay_invalid<AN...>::type;
 template<class T, class Duration, class Coordination>
 struct delay
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
-    typedef rxu::decay_t<Duration> duration_type;
+    using source_value_type = rxu::decay_t<T>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
+    using duration_type = rxu::decay_t<Duration>;
 
     struct delay_values
     {
@@ -68,10 +68,10 @@ struct delay
     template<class Subscriber>
     struct delay_observer
     {
-        typedef delay_observer<Subscriber> this_type;
-        typedef rxu::decay_t<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using this_type = delay_observer<Subscriber>;
+        using value_type = rxu::decay_t<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
 
         struct delay_subscriber_values : public delay_values
         {

--- a/Rx/v2/src/rxcpp/operators/rx-distinct.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-distinct.hpp
@@ -39,15 +39,15 @@ using distinct_invalid_t = typename distinct_invalid<AN...>::type;
 template<class T>
 struct distinct
 {
-    typedef rxu::decay_t<T> source_value_type;
+    using source_value_type = rxu::decay_t<T>;
 
     template<class Subscriber>
     struct distinct_observer
     {
-        typedef distinct_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = distinct_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         mutable std::unordered_set<source_value_type, rxcpp::filtered_hash<source_value_type>> remembered;
 

--- a/Rx/v2/src/rxcpp/operators/rx-distinct_until_changed.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-distinct_until_changed.hpp
@@ -41,8 +41,8 @@ using distinct_until_changed_invalid_t = typename distinct_until_changed_invalid
 template<class T, class BinaryPredicate>
 struct distinct_until_changed
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<BinaryPredicate> predicate_type;
+    using source_value_type = rxu::decay_t<T>;
+    using predicate_type = rxu::decay_t<BinaryPredicate>;
 
     predicate_type pred;
 
@@ -54,10 +54,10 @@ struct distinct_until_changed
     template<class Subscriber>
     struct distinct_until_changed_observer
     {
-        typedef distinct_until_changed_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = distinct_until_changed_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
 
         dest_type dest;
         predicate_type pred;

--- a/Rx/v2/src/rxcpp/operators/rx-element_at.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-element_at.hpp
@@ -38,7 +38,7 @@ using element_at_invalid_t = typename element_at_invalid<AN...>::type;
     
 template<class T>
 struct element_at {
-    typedef rxu::decay_t<T> source_value_type;
+    using source_value_type = rxu::decay_t<T>;
 
     struct element_at_values {
         element_at_values(int i)
@@ -58,10 +58,10 @@ struct element_at {
     template<class Subscriber>
     struct element_at_observer : public element_at_values
     {
-        typedef element_at_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = element_at_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         mutable int current;
 

--- a/Rx/v2/src/rxcpp/operators/rx-filter.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-filter.hpp
@@ -41,8 +41,8 @@ using filter_invalid_t = typename filter_invalid<AN...>::type;
 template<class T, class Predicate>
 struct filter
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Predicate> test_type;
+    using source_value_type = rxu::decay_t<T>;
+    using test_type = rxu::decay_t<Predicate>;
     test_type test;
 
     filter(test_type t)
@@ -53,10 +53,10 @@ struct filter
     template<class Subscriber>
     struct filter_observer
     {
-        typedef filter_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = filter_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         mutable test_type test;
 

--- a/Rx/v2/src/rxcpp/operators/rx-finally.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-finally.hpp
@@ -45,8 +45,8 @@ using finally_invalid_t = typename finally_invalid<AN...>::type;
 template<class T, class LastCall>
 struct finally
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<LastCall> last_call_type;
+    using source_value_type = rxu::decay_t<T>;
+    using last_call_type = rxu::decay_t<LastCall>;
     last_call_type last_call;
 
     finally(last_call_type lc)
@@ -57,10 +57,10 @@ struct finally
     template<class Subscriber>
     struct finally_observer
     {
-        typedef finally_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = finally_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
 
         finally_observer(dest_type d)

--- a/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
@@ -60,26 +60,26 @@ struct flat_map_traits {
 
     struct tag_not_valid {};
     template<class CV, class CCS>
-    static auto collection_check(int) -> decltype((*(CCS*)nullptr)(*(CV*)nullptr));
+    static auto collection_check(int) -> decltype(std::declval<CCS>()(std::declval<CV>()));
     template<class CV, class CCS>
     static tag_not_valid collection_check(...);
 
     static_assert(!std::is_same<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>::value, "flat_map CollectionSelector must be a function with the signature observable(flat_map::source_value_type)");
 
-    typedef rxu::decay_t<decltype((*(collection_selector_type*)nullptr)((*(source_value_type*)nullptr)))> collection_type;
+    using collection_type = rxu::decay_t<decltype(std::declval<collection_selector_type>()(std::declval<source_value_type>()))>;
 
     static_assert(is_observable<collection_type>::value, "flat_map CollectionSelector must return an observable");
 
     typedef typename collection_type::value_type collection_value_type;
 
     template<class CV, class CCV, class CRS>
-    static auto result_check(int) -> decltype((*(CRS*)nullptr)(*(CV*)nullptr, *(CCV*)nullptr));
+    static auto result_check(int) -> decltype(std::declval<CRS>()(std::declval<CV>(), std::declval<CCV>()));
     template<class CV, class CCV, class CRS>
     static tag_not_valid result_check(...);
 
     static_assert(!std::is_same<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>::value, "flat_map ResultSelector must be a function with the signature flat_map::value_type(flat_map::source_value_type, flat_map::collection_value_type)");
 
-    typedef rxu::decay_t<decltype((*(result_selector_type*)nullptr)(*(source_value_type*)nullptr, *(collection_value_type*)nullptr))> value_type;
+    using value_type = rxu::decay_t<decltype((std::declval<result_selector_type>())(std::declval<source_value_type>(), std::declval<collection_value_type>()))> ;
 };
 
 template<class Observable, class CollectionSelector, class ResultSelector, class Coordination>

--- a/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
@@ -64,7 +64,7 @@ struct flat_map_traits {
     template<class CV, class CCS>
     static tag_not_valid collection_check(...);
 
-    static_assert(!std::is_same<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>::value, "flat_map CollectionSelector must be a function with the signature observable(flat_map::source_value_type)");
+    static_assert(!std::is_same_v<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>, "flat_map CollectionSelector must be a function with the signature observable(flat_map::source_value_type)");
 
     using collection_type = rxu::decay_t<decltype(std::declval<collection_selector_type>()(std::declval<source_value_type>()))>;
 
@@ -77,7 +77,7 @@ struct flat_map_traits {
     template<class CV, class CCV, class CRS>
     static tag_not_valid result_check(...);
 
-    static_assert(!std::is_same<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>::value, "flat_map ResultSelector must be a function with the signature flat_map::value_type(flat_map::source_value_type, flat_map::collection_value_type)");
+    static_assert(!std::is_same_v<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>, "flat_map ResultSelector must be a function with the signature flat_map::value_type(flat_map::source_value_type, flat_map::collection_value_type)");
 
     using value_type = rxu::decay_t<decltype((std::declval<result_selector_type>())(std::declval<source_value_type>(), std::declval<collection_value_type>()))> ;
 };

--- a/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
@@ -51,12 +51,12 @@ using flat_map_invalid_t = typename flat_map_invalid<AN...>::type;
 
 template<class Observable, class CollectionSelector, class ResultSelector, class Coordination>
 struct flat_map_traits {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<CollectionSelector> collection_selector_type;
-    typedef rxu::decay_t<ResultSelector> result_selector_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
+    using source_type = rxu::decay_t<Observable>;
+    using collection_selector_type = rxu::decay_t<CollectionSelector>;
+    using result_selector_type = rxu::decay_t<ResultSelector>;
+    using coordination_type = rxu::decay_t<Coordination>;
 
-    typedef typename source_type::value_type source_value_type;
+    using source_value_type = typename source_type::value_type;
 
     struct tag_not_valid {};
     template<class CV, class CCS>
@@ -70,7 +70,7 @@ struct flat_map_traits {
 
     static_assert(is_observable<collection_type>::value, "flat_map CollectionSelector must return an observable");
 
-    typedef typename collection_type::value_type collection_value_type;
+    using collection_value_type = typename collection_type::value_type;
 
     template<class CV, class CCV, class CRS>
     static auto result_check(int) -> decltype(std::declval<CRS>()(std::declval<CV>(), std::declval<CCV>()));
@@ -86,19 +86,19 @@ template<class Observable, class CollectionSelector, class ResultSelector, class
 struct flat_map
     : public operator_base<rxu::value_type_t<flat_map_traits<Observable, CollectionSelector, ResultSelector, Coordination>>>
 {
-    typedef flat_map<Observable, CollectionSelector, ResultSelector, Coordination> this_type;
-    typedef flat_map_traits<Observable, CollectionSelector, ResultSelector, Coordination> traits;
+    using this_type = flat_map<Observable, CollectionSelector, ResultSelector, Coordination>;
+    using traits = flat_map_traits<Observable, CollectionSelector, ResultSelector, Coordination>;
 
-    typedef typename traits::source_type source_type;
-    typedef typename traits::collection_selector_type collection_selector_type;
-    typedef typename traits::result_selector_type result_selector_type;
+    using source_type = typename traits::source_type;
+    using collection_selector_type = typename traits::collection_selector_type;
+    using result_selector_type = typename traits::result_selector_type;
 
-    typedef typename traits::source_value_type source_value_type;
-    typedef typename traits::collection_type collection_type;
-    typedef typename traits::collection_value_type collection_value_type;
+    using source_value_type = typename traits::source_value_type;
+    using collection_type = typename traits::collection_type;
+    using collection_value_type = typename traits::collection_value_type;
 
-    typedef typename traits::coordination_type coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = typename traits::coordination_type;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct values
     {
@@ -125,7 +125,7 @@ struct flat_map
     void on_subscribe(Subscriber scbr) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct state_type
             : public std::enable_shared_from_this<state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-group_by.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-group_by.hpp
@@ -51,8 +51,8 @@ using group_by_invalid_t = typename group_by_invalid<AN...>::type;
 template<class T, class Selector>
 struct is_group_by_selector_for {
 
-    typedef rxu::decay_t<Selector> selector_type;
-    typedef T source_value_type;
+    using selector_type = rxu::decay_t<Selector>;
+    using source_value_type = T;
 
     struct tag_not_valid {};
     template<class CV, class CS>
@@ -60,49 +60,49 @@ struct is_group_by_selector_for {
     template<class CV, class CS>
     static tag_not_valid check(...);
 
-    typedef decltype(check<source_value_type, selector_type>(0)) type;
+    using type = decltype(check<source_value_type, selector_type>(0));
     static const bool value = !std::is_same<type, tag_not_valid>::value;
 };
 
 template<class T, class Observable, class KeySelector, class MarbleSelector, class BinaryPredicate, class DurationSelector>
 struct group_by_traits
 {
-    typedef T source_value_type;
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<KeySelector> key_selector_type;
-    typedef rxu::decay_t<MarbleSelector> marble_selector_type;
-    typedef rxu::decay_t<BinaryPredicate> predicate_type;
-    typedef rxu::decay_t<DurationSelector> duration_selector_type;
+    using source_value_type = T;
+    using source_type = rxu::decay_t<Observable>;
+    using key_selector_type = rxu::decay_t<KeySelector>;
+    using marble_selector_type = rxu::decay_t<MarbleSelector>;
+    using predicate_type = rxu::decay_t<BinaryPredicate>;
+    using duration_selector_type = rxu::decay_t<DurationSelector>;
 
     static_assert(is_group_by_selector_for<source_value_type, key_selector_type>::value, "group_by KeySelector must be a function with the signature key_type(source_value_type)");
 
-    typedef typename is_group_by_selector_for<source_value_type, key_selector_type>::type key_type;
+    using key_type = typename is_group_by_selector_for<source_value_type, key_selector_type>::type;
 
     static_assert(is_group_by_selector_for<source_value_type, marble_selector_type>::value, "group_by MarbleSelector must be a function with the signature marble_type(source_value_type)");
 
-    typedef typename is_group_by_selector_for<source_value_type, marble_selector_type>::type marble_type;
+    using marble_type = typename is_group_by_selector_for<source_value_type, marble_selector_type>::type;
 
-    typedef rxsub::subject<marble_type> subject_type;
+    using subject_type = rxsub::subject<marble_type>;
 
-    typedef std::map<key_type, typename subject_type::subscriber_type, predicate_type> key_subscriber_map_type;
+    using key_subscriber_map_type = std::map<key_type, typename subject_type::subscriber_type, predicate_type>;
 
-    typedef grouped_observable<key_type, marble_type> grouped_observable_type;
+    using grouped_observable_type = grouped_observable<key_type, marble_type>;
 };
 
 template<class T, class Observable, class KeySelector, class MarbleSelector, class BinaryPredicate, class DurationSelector>
 struct group_by
 {
-    typedef group_by_traits<T, Observable, KeySelector, MarbleSelector, BinaryPredicate, DurationSelector> traits_type;
-    typedef typename traits_type::key_selector_type key_selector_type;
-    typedef typename traits_type::marble_selector_type marble_selector_type;
-    typedef typename traits_type::marble_type marble_type;
-    typedef typename traits_type::predicate_type predicate_type;
-    typedef typename traits_type::duration_selector_type duration_selector_type;
-    typedef typename traits_type::subject_type subject_type;
-    typedef typename traits_type::key_type key_type;
+    using traits_type = group_by_traits<T, Observable, KeySelector, MarbleSelector, BinaryPredicate, DurationSelector>;
+    using key_selector_type = typename traits_type::key_selector_type;
+    using marble_selector_type = typename traits_type::marble_selector_type;
+    using marble_type = typename traits_type::marble_type;
+    using predicate_type = typename traits_type::predicate_type;
+    using duration_selector_type = typename traits_type::duration_selector_type;
+    using subject_type = typename traits_type::subject_type;
+    using key_type = typename traits_type::key_type;
 
-    typedef typename traits_type::key_subscriber_map_type group_map_type;
-    typedef std::vector<typename composite_subscription::weak_subscription> bindings_type;
+    using group_map_type = typename traits_type::key_subscriber_map_type;
+    using bindings_type = std::vector<typename composite_subscription::weak_subscription>;
 
     struct group_by_state_type 
     {
@@ -180,10 +180,10 @@ struct group_by
     template<class Subscriber>
     struct group_by_observer : public group_by_values
     {
-        typedef group_by_observer<Subscriber> this_type;
-        typedef typename traits_type::grouped_observable_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using this_type = group_by_observer<Subscriber>;
+        using value_type = typename traits_type::grouped_observable_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
 
         dest_type dest;
 
@@ -278,10 +278,10 @@ struct group_by
 template<class KeySelector, class MarbleSelector, class BinaryPredicate, class DurationSelector>
 class group_by_factory
 {
-    typedef rxu::decay_t<KeySelector> key_selector_type;
-    typedef rxu::decay_t<MarbleSelector> marble_selector_type;
-    typedef rxu::decay_t<BinaryPredicate> predicate_type;
-    typedef rxu::decay_t<DurationSelector> duration_selector_type;
+    using key_selector_type = rxu::decay_t<KeySelector>;
+    using marble_selector_type = rxu::decay_t<MarbleSelector>;
+    using predicate_type = rxu::decay_t<BinaryPredicate>;
+    using duration_selector_type = rxu::decay_t<DurationSelector>;
     key_selector_type keySelector;
     marble_selector_type marbleSelector;
     predicate_type predicate;
@@ -297,9 +297,9 @@ public:
     template<class Observable>
     struct group_by_factory_traits
     {
-        typedef rxu::value_type_t<rxu::decay_t<Observable>> value_type;
-        typedef detail::group_by_traits<value_type, Observable, KeySelector, MarbleSelector, BinaryPredicate, DurationSelector> traits_type;
-        typedef detail::group_by<value_type, Observable, KeySelector, MarbleSelector, BinaryPredicate, DurationSelector> group_by_type;
+        using value_type = rxu::value_type_t <rxu::decay_t<Observable>>;
+        using traits_type = detail::group_by_traits<value_type, Observable, KeySelector, MarbleSelector, BinaryPredicate, DurationSelector>;
+        using group_by_type = detail::group_by<value_type, Observable, KeySelector, MarbleSelector, BinaryPredicate, DurationSelector>;
     };
     template<class Observable>
     auto operator()(Observable&& source)

--- a/Rx/v2/src/rxcpp/operators/rx-group_by.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-group_by.hpp
@@ -56,7 +56,7 @@ struct is_group_by_selector_for {
 
     struct tag_not_valid {};
     template<class CV, class CS>
-    static auto check(int) -> decltype((*(CS*)nullptr)(*(CV*)nullptr));
+    static auto check(int) -> decltype(std::declval<CS>()(std::declval<CV>()));
     template<class CV, class CS>
     static tag_not_valid check(...);
 

--- a/Rx/v2/src/rxcpp/operators/rx-group_by.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-group_by.hpp
@@ -61,7 +61,7 @@ struct is_group_by_selector_for {
     static tag_not_valid check(...);
 
     using type = decltype(check<source_value_type, selector_type>(0));
-    static const bool value = !std::is_same<type, tag_not_valid>::value;
+    static const bool value = !std::is_same_v<type, tag_not_valid>;
 };
 
 template<class T, class Observable, class KeySelector, class MarbleSelector, class BinaryPredicate, class DurationSelector>

--- a/Rx/v2/src/rxcpp/operators/rx-ignore_elements.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-ignore_elements.hpp
@@ -36,15 +36,15 @@ using ignore_elements_invalid_t = typename ignore_elements_invalid<AN...>::type;
 
 template<class T>
 struct ignore_elements {
-    typedef rxu::decay_t<T> source_value_type;
+    using source_value_type = rxu::decay_t<T>;
 
     template<class Subscriber>
     struct ignore_elements_observer
     {
-        typedef ignore_elements_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = ignore_elements_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
 
         ignore_elements_observer(dest_type d)

--- a/Rx/v2/src/rxcpp/operators/rx-lift.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-lift.hpp
@@ -50,19 +50,19 @@ namespace detail {
 template<class ResultType, class SourceOperator, class Operator>
 struct lift_traits
 {
-    typedef rxu::decay_t<ResultType> result_value_type;
-    typedef rxu::decay_t<SourceOperator> source_operator_type;
-    typedef rxu::decay_t<Operator> operator_type;
+    using result_value_type = rxu::decay_t<ResultType>;
+    using source_operator_type = rxu::decay_t<SourceOperator>;
+    using operator_type = rxu::decay_t<Operator>;
 
-    typedef typename source_operator_type::value_type source_value_type;
+    using source_value_type = typename source_operator_type::value_type;
 };
 
 template<class ResultType, class SourceOperator, class Operator>
 struct lift_operator : public operator_base<typename lift_traits<ResultType, SourceOperator, Operator>::result_value_type>
 {
-    typedef lift_traits<ResultType, SourceOperator, Operator> traits;
-    typedef typename traits::source_operator_type source_operator_type;
-    typedef typename traits::operator_type operator_type;
+    using traits = lift_traits<ResultType, SourceOperator, Operator>;
+    using source_operator_type = typename traits::source_operator_type;
+    using operator_type = typename traits::operator_type;
     source_operator_type source;
     operator_type chain;
 
@@ -83,7 +83,7 @@ struct lift_operator : public operator_base<typename lift_traits<ResultType, Sou
 template<class ResultType, class Operator>
 class lift_factory
 {
-    typedef rxu::decay_t<Operator> operator_type;
+    using operator_type = rxu::decay_t<Operator>;
     operator_type chain;
 public:
     lift_factory(operator_type op) : chain(std::move(op)) {}

--- a/Rx/v2/src/rxcpp/operators/rx-lift.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-lift.hpp
@@ -27,7 +27,7 @@ struct is_lift_function_for {
 
     struct tag_not_valid {};
     template<class CS, class CF>
-    static auto check(int) -> decltype((*(CF*)nullptr)(*(CS*)nullptr));
+    static auto check(int) -> decltype(std::declval<CF>()(std::declval<CS>()));
     template<class CS, class CF>
     static tag_not_valid check(...);
 

--- a/Rx/v2/src/rxcpp/operators/rx-map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-map.hpp
@@ -41,8 +41,8 @@ using map_invalid_t = typename map_invalid<AN...>::type;
 template<class T, class Selector>
 struct map
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Selector> select_type;
+    using source_value_type = rxu::decay_t<T>;
+    using select_type = rxu::decay_t<Selector>;
     using value_type = decltype(std::declval<select_type>()(std::declval<source_value_type>()));
     select_type selector;
 
@@ -54,10 +54,10 @@ struct map
     template<class Subscriber>
     struct map_observer
     {
-        typedef map_observer<Subscriber> this_type;
+        using this_type = map_observer<Subscriber>;
         using value_type = decltype(std::declval<select_type>()(std::declval<source_value_type>()));
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<source_value_type, this_type> observer_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<source_value_type, this_type>;
         dest_type dest;
         mutable select_type selector;
 

--- a/Rx/v2/src/rxcpp/operators/rx-map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-map.hpp
@@ -43,7 +43,7 @@ struct map
 {
     typedef rxu::decay_t<T> source_value_type;
     typedef rxu::decay_t<Selector> select_type;
-    typedef decltype((*(select_type*)nullptr)(*(source_value_type*)nullptr)) value_type;
+    using value_type = decltype(std::declval<select_type>()(std::declval<source_value_type>()));
     select_type selector;
 
     map(select_type s)
@@ -55,7 +55,7 @@ struct map
     struct map_observer
     {
         typedef map_observer<Subscriber> this_type;
-        typedef decltype((*(select_type*)nullptr)(*(source_value_type*)nullptr)) value_type;
+        using value_type = decltype(std::declval<select_type>()(std::declval<source_value_type>()));
         typedef rxu::decay_t<Subscriber> dest_type;
         typedef observer<source_value_type, this_type> observer_type;
         dest_type dest;

--- a/Rx/v2/src/rxcpp/operators/rx-merge.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-merge.hpp
@@ -68,16 +68,16 @@ struct merge
     //static_assert(is_observable<Observable>::value, "merge requires an observable");
     //static_assert(is_observable<T>::value, "merge requires an observable that contains observables");
 
-    typedef merge<T, Observable, Coordination> this_type;
+    using this_type = merge<T, Observable, Coordination>;
 
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Observable> source_type;
+    using source_value_type = rxu::decay_t<T>;
+    using source_type = rxu::decay_t<Observable>;
 
-    typedef typename source_type::source_operator_type source_operator_type;
-    typedef typename source_value_type::value_type value_type;
+    using source_operator_type = typename source_type::source_operator_type;
+    using value_type = typename source_value_type::value_type;
 
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct values
     {
@@ -100,7 +100,7 @@ struct merge
     void on_subscribe(Subscriber scbr) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct merge_state_type
             : public std::enable_shared_from_this<merge_state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-merge_delay_error.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-merge_delay_error.hpp
@@ -61,16 +61,16 @@ struct merge_delay_error
         //static_assert(is_observable<Observable>::value, "merge requires an observable");
         //static_assert(is_observable<T>::value, "merge requires an observable that contains observables");
 
-        typedef merge_delay_error<T, Observable, Coordination> this_type;
+    using this_type = merge_delay_error<T, Observable, Coordination>;
 
-        typedef rxu::decay_t<T> source_value_type;
-        typedef rxu::decay_t<Observable> source_type;
+    using source_value_type = rxu::decay_t<T>;
+    using source_type = rxu::decay_t<Observable>;
 
-        typedef typename source_type::source_operator_type source_operator_type;
-        typedef typename source_value_type::value_type value_type;
+    using source_operator_type = typename source_type::source_operator_type;
+    using value_type = typename source_value_type::value_type;
 
-        typedef rxu::decay_t<Coordination> coordination_type;
-        typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
         struct values
         {
@@ -93,7 +93,7 @@ struct merge_delay_error
         void on_subscribe(Subscriber scbr) const {
                 static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-                typedef Subscriber output_type;
+            using output_type = Subscriber;
 
                 struct merge_state_type
                         : public std::enable_shared_from_this<merge_state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-multicast.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-multicast.hpp
@@ -35,8 +35,8 @@ using multicast_invalid_t = typename multicast_invalid<AN...>::type;
 template<class T, class Observable, class Subject>
 struct multicast : public operator_base<T>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<Subject> subject_type;
+    using source_type = rxu::decay_t<Observable>;
+    using subject_type = rxu::decay_t<Subject>;
 
     struct multicast_state : public std::enable_shared_from_this<multicast_state>
     {

--- a/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
@@ -44,10 +44,10 @@ using observe_on_invalid_t = typename observe_on_invalid<AN...>::type;
 template<class T, class Coordination>
 struct observe_on
 {
-    typedef rxu::decay_t<T> source_value_type;
+    using source_value_type = rxu::decay_t<T>;
 
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     coordination_type coordination;
 
@@ -59,14 +59,14 @@ struct observe_on
     template<class Subscriber>
     struct observe_on_observer
     {
-        typedef observe_on_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = observe_on_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
 
-        typedef rxn::notification<T> notification_type;
-        typedef typename notification_type::type base_notification_type;
-        typedef std::deque<base_notification_type> queue_type;
+        using notification_type = rxn::notification<T>;
+        using base_notification_type = typename notification_type::type;
+        using queue_type = std::deque<base_notification_type>;
 
         struct mode
         {
@@ -305,7 +305,7 @@ public:
 
     explicit observe_on_one_worker(rxsc::scheduler sc) : factory(sc) {}
 
-    typedef coordinator<input_type> coordinator_type;
+    using coordinator_type = coordinator<input_type>;
 
     inline rxsc::scheduler::clock_type::time_point now() const {
         return factory.now();

--- a/Rx/v2/src/rxcpp/operators/rx-on_error_resume_next.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-on_error_resume_next.hpp
@@ -42,8 +42,8 @@ using on_error_resume_next_invalid_t = typename on_error_resume_next_invalid<AN.
 template<class T, class Selector>
 struct on_error_resume_next
 {
-    typedef rxu::decay_t<T> value_type;
-    typedef rxu::decay_t<Selector> select_type;
+    using value_type = rxu::decay_t<T>;
+    using select_type = rxu::decay_t<Selector>;
     using fallback_type = decltype(std::declval<select_type>()(rxu::error_ptr()));
     select_type selector;
 
@@ -55,12 +55,12 @@ struct on_error_resume_next
     template<class Subscriber>
     struct on_error_resume_next_observer
     {
-        typedef on_error_resume_next_observer<Subscriber> this_type;
-        typedef rxu::decay_t<T> value_type;
-        typedef rxu::decay_t<Selector> select_type;
+        using this_type = on_error_resume_next_observer<Subscriber>;
+        using value_type = rxu::decay_t<T>;
+        using select_type = rxu::decay_t<Selector>;
         using fallback_type = decltype(std::declval<select_type>()(rxu::error_ptr()));
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
         dest_type dest;
         composite_subscription lifetime;
         select_type selector;

--- a/Rx/v2/src/rxcpp/operators/rx-on_error_resume_next.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-on_error_resume_next.hpp
@@ -44,7 +44,7 @@ struct on_error_resume_next
 {
     typedef rxu::decay_t<T> value_type;
     typedef rxu::decay_t<Selector> select_type;
-    typedef decltype((*(select_type*)nullptr)(rxu::error_ptr())) fallback_type;
+    using fallback_type = decltype(std::declval<select_type>()(rxu::error_ptr()));
     select_type selector;
 
     on_error_resume_next(select_type s)
@@ -58,7 +58,7 @@ struct on_error_resume_next
         typedef on_error_resume_next_observer<Subscriber> this_type;
         typedef rxu::decay_t<T> value_type;
         typedef rxu::decay_t<Selector> select_type;
-        typedef decltype((*(select_type*)nullptr)(rxu::error_ptr())) fallback_type;
+        using fallback_type = decltype(std::declval<select_type>()(rxu::error_ptr()));
         typedef rxu::decay_t<Subscriber> dest_type;
         typedef observer<T, this_type> observer_type;
         dest_type dest;

--- a/Rx/v2/src/rxcpp/operators/rx-pairwise.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-pairwise.hpp
@@ -41,16 +41,16 @@ using pairwise_invalid_t = typename pairwise_invalid<AN...>::type;
 template<class T>
 struct pairwise
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef std::tuple<source_value_type, source_value_type> value_type;
+    using source_value_type = rxu::decay_t<T>;
+    using value_type = std::tuple<source_value_type, source_value_type>;
 
     template<class Subscriber>
     struct pairwise_observer
     {
-        typedef pairwise_observer<Subscriber> this_type;
-        typedef std::tuple<source_value_type, source_value_type> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using this_type = pairwise_observer<Subscriber>;
+        using value_type = std::tuple<source_value_type, source_value_type>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
         dest_type dest;
         mutable rxu::detail::maybe<source_value_type> remembered;
 

--- a/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
@@ -67,8 +67,8 @@ using reduce_invalid_t = typename reduce_invalid<AN...>::type;
 template<class Seed, class ResultSelector>
 struct is_result_function_for {
 
-    typedef rxu::decay_t<ResultSelector> result_selector_type;
-    typedef rxu::decay_t<Seed> seed_type;
+    using result_selector_type = rxu::decay_t<ResultSelector>;
+    using seed_type = rxu::decay_t<Seed>;
 
     struct tag_not_valid {};
 
@@ -77,36 +77,36 @@ struct is_result_function_for {
     template<class CS, class CRS>
     static tag_not_valid check(...);
 
-    typedef rxu::decay_t<decltype(check<seed_type, result_selector_type>(0))> type;
+    using type = rxu::decay_t<decltype(check<seed_type, result_selector_type>(0))>;
     static const bool value = !std::is_same<type, tag_not_valid>::value;
 };
 
 template<class T, class Observable, class Accumulator, class ResultSelector, class Seed>
 struct reduce_traits
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<Accumulator> accumulator_type;
-    typedef rxu::decay_t<ResultSelector> result_selector_type;
-    typedef rxu::decay_t<Seed> seed_type;
+    using source_type = rxu::decay_t<Observable>;
+    using accumulator_type = rxu::decay_t<Accumulator>;
+    using result_selector_type = rxu::decay_t<ResultSelector>;
+    using seed_type = rxu::decay_t<Seed>;
 
-    typedef T source_value_type;
+    using source_value_type = T;
 
-    typedef typename is_result_function_for<seed_type, result_selector_type>::type value_type;
+    using value_type = typename is_result_function_for<seed_type, result_selector_type>::type;
 };
 
 template<class T, class Observable, class Accumulator, class ResultSelector, class Seed>
 struct reduce : public operator_base<rxu::value_type_t<reduce_traits<T, Observable, Accumulator, ResultSelector, Seed>>>
 {
-    typedef reduce<T, Observable, Accumulator, ResultSelector, Seed> this_type;
-    typedef reduce_traits<T, Observable, Accumulator, ResultSelector, Seed> traits;
+    using this_type = reduce<T, Observable, Accumulator, ResultSelector, Seed>;
+    using traits = reduce_traits<T, Observable, Accumulator, ResultSelector, Seed>;
 
-    typedef typename traits::source_type source_type;
-    typedef typename traits::accumulator_type accumulator_type;
-    typedef typename traits::result_selector_type result_selector_type;
-    typedef typename traits::seed_type seed_type;
+    using source_type = typename traits::source_type;
+    using accumulator_type = typename traits::accumulator_type;
+    using result_selector_type = typename traits::result_selector_type;
+    using seed_type = typename traits::seed_type;
 
-    typedef typename traits::source_value_type source_value_type;
-    typedef typename traits::value_type value_type;
+    using source_value_type = typename traits::source_value_type;
+    using value_type = typename traits::value_type;
 
     struct reduce_initial_type
     {
@@ -187,7 +187,7 @@ private:
 
 template<class T>
 struct initialize_seeder {
-    typedef T seed_type;
+    using seed_type = T;
     static seed_type seed() {
         return seed_type{};
     }
@@ -249,7 +249,7 @@ struct average {
 
 template<class T>
 struct sum {
-    typedef rxu::maybe<T> seed_type;
+    using seed_type = rxu::maybe<T>;
     static seed_type seed() {
         return seed_type();
     }
@@ -270,7 +270,7 @@ struct sum {
 
 template<class T>
 struct max {
-    typedef rxu::maybe<T> seed_type;
+    using seed_type = rxu::maybe<T>;
     static seed_type seed() {
         return seed_type();
     }
@@ -289,7 +289,7 @@ struct max {
 
 template<class T>
 struct min {
-    typedef rxu::maybe<T> seed_type;
+    using seed_type = rxu::maybe<T>;
     static seed_type seed() {
         return seed_type();
     }

--- a/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
@@ -78,7 +78,7 @@ struct is_result_function_for {
     static tag_not_valid check(...);
 
     using type = rxu::decay_t<decltype(check<seed_type, result_selector_type>(0))>;
-    static const bool value = !std::is_same<type, tag_not_valid>::value;
+    static const bool value = !std::is_same_v<type, tag_not_valid>;
 };
 
 template<class T, class Observable, class Accumulator, class ResultSelector, class Seed>

--- a/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
@@ -73,7 +73,7 @@ struct is_result_function_for {
     struct tag_not_valid {};
 
     template<class CS, class CRS>
-    static auto check(int) -> decltype((*(CRS*)nullptr)(*(CS*)nullptr));
+    static auto check(int) -> decltype(std::declval<CRS>()(std::declval<CS>()));
     template<class CS, class CRS>
     static tag_not_valid check(...);
 
@@ -539,7 +539,7 @@ struct member_overload<first_tag>
         class Seed = decltype(Operation::seed()),
         class Accumulator = Operation,
         class ResultSelector = Operation,
-        class TakeOne = decltype(((rxu::decay_t<Observable>*)nullptr)->take(1)),
+        class TakeOne = decltype(std::declval<rxu::decay_t<Observable>>().take(1)),
         class Reduce = rxo::detail::reduce<SValue, rxu::decay_t<TakeOne>, rxu::decay_t<Accumulator>, rxu::decay_t<ResultSelector>, rxu::decay_t<Seed>>,
         class RValue = rxu::value_type_t<Reduce>,
         class Result = observable<RValue, Reduce>>

--- a/Rx/v2/src/rxcpp/operators/rx-ref_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-ref_count.hpp
@@ -84,8 +84,8 @@ template<class T,
          class Observable = void> // note: type order flipped versus the operator.
 struct ref_count : public operator_base<T>
 {
-    typedef rxu::decay_t<Observable> observable_type;
-    typedef rxu::decay_t<ConnectableObservable> connectable_type;
+    using observable_type = rxu::decay_t<Observable>;
+    using connectable_type = rxu::decay_t<ConnectableObservable>;
 
     // ref_count() == false
     // ref_count(other) == true

--- a/Rx/v2/src/rxcpp/operators/rx-retry-repeat-common.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-retry-repeat-common.hpp
@@ -18,7 +18,7 @@ namespace rxcpp {
         struct state_type : public std::enable_shared_from_this<state_type<Values, Subscriber, EventHandlers, T>>,
                             public Values {
 
-          typedef Subscriber output_type;
+            using output_type = Subscriber;
           state_type(const Values& i, const output_type& oarg)
             : Values(i),
               source_lifetime(composite_subscription::empty()),
@@ -60,8 +60,8 @@ namespace rxcpp {
         // Finite case (explicitely limited with the number of times)
         template <class EventHandlers, class T, class Observable, class Count>
         struct finite : public operator_base<T> {
-          typedef rxu::decay_t<Observable> source_type;
-          typedef rxu::decay_t<Count> count_type;
+            using source_type = rxu::decay_t<Observable>;
+            using count_type = rxu::decay_t<Count>;
 
           struct values {
             values(source_type s, count_type t)
@@ -92,7 +92,7 @@ namespace rxcpp {
 
           template<class Subscriber>
           void on_subscribe(const Subscriber& s) const {
-            typedef state_type<values, Subscriber, EventHandlers, T> state_t;
+              using state_t = state_type<values, Subscriber, EventHandlers, T>;
             // take a copy of the values for each subscription
             auto state = std::make_shared<state_t>(initial_, s);      
             if (initial_.completed_predicate()) {
@@ -111,7 +111,7 @@ namespace rxcpp {
         // Infinite case
         template <class EventHandlers, class T, class Observable>
         struct infinite : public operator_base<T> {
-          typedef rxu::decay_t<Observable> source_type;
+            using source_type = rxu::decay_t<Observable>;
     
           struct values {
             values(source_type s)
@@ -135,7 +135,7 @@ namespace rxcpp {
 
           template<class Subscriber>
           void on_subscribe(const Subscriber& s) const {
-            typedef state_type<values, Subscriber, EventHandlers, T> state_t;
+              using state_t = state_type<values, Subscriber, EventHandlers, T>;
             // take a copy of the values for each subscription
             auto state = std::make_shared<state_t>(initial_, s);
             // start the first iteration

--- a/Rx/v2/src/rxcpp/operators/rx-sample_time.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-sample_time.hpp
@@ -43,10 +43,10 @@ using sample_with_time_invalid_t = typename sample_with_time_invalid<AN...>::typ
 template<class T, class Duration, class Coordination>
 struct sample_with_time
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
-    typedef rxu::decay_t<Duration> duration_type;
+    using source_value_type = rxu::decay_t<T>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
+    using duration_type = rxu::decay_t<Duration>;
 
     struct sample_with_time_value
     {
@@ -68,10 +68,10 @@ struct sample_with_time
     template<class Subscriber>
     struct sample_with_time_observer
     {
-        typedef sample_with_time_observer<Subscriber> this_type;
-        typedef T value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = sample_with_time_observer<Subscriber>;
+        using value_type = T;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
 
         struct sample_with_time_subscriber_value : public sample_with_time_value
         {

--- a/Rx/v2/src/rxcpp/operators/rx-scan.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-scan.hpp
@@ -43,9 +43,9 @@ using scan_invalid_t = typename scan_invalid<AN...>::type;
 template<class T, class Observable, class Accumulator, class Seed>
 struct scan : public operator_base<rxu::decay_t<Seed>>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<Accumulator> accumulator_type;
-    typedef rxu::decay_t<Seed> seed_type;
+    using source_type = rxu::decay_t<Observable>;
+    using accumulator_type = rxu::decay_t<Accumulator>;
+    using seed_type = rxu::decay_t<Seed>;
 
     struct scan_initial_type
     {

--- a/Rx/v2/src/rxcpp/operators/rx-sequence_equal.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-sequence_equal.hpp
@@ -45,13 +45,13 @@ using sequence_equal_invalid_t = typename sequence_equal_invalid<AN...>::type;
 template<class T, class Observable, class OtherObservable, class BinaryPredicate, class Coordination>
 struct sequence_equal : public operator_base<bool>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<OtherObservable> other_source_type;
-    typedef typename other_source_type::value_type other_source_value_type;
-    typedef rxu::decay_t<BinaryPredicate> predicate_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using source_type = rxu::decay_t<Observable>;
+    using source_value_type = rxu::decay_t<T>;
+    using other_source_type = rxu::decay_t<OtherObservable>;
+    using other_source_value_type = typename other_source_type::value_type;
+    using predicate_type = rxu::decay_t<BinaryPredicate>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct values {
         values(source_type s, other_source_type t, predicate_type pred, coordination_type sf)
@@ -78,7 +78,7 @@ struct sequence_equal : public operator_base<bool>
     template<class Subscriber>
     void on_subscribe(Subscriber s) const {
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct state_type
             : public std::enable_shared_from_this<state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-skip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip.hpp
@@ -42,8 +42,8 @@ using skip_invalid_t = typename skip_invalid<AN...>::type;
 template<class T, class Observable, class Count>
 struct skip : public operator_base<T>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<Count> count_type;
+    using source_type = rxu::decay_t<Observable>;
+    using count_type = rxu::decay_t<Count>;
     struct values
     {
         values(source_type s, count_type t)
@@ -74,7 +74,7 @@ struct skip : public operator_base<T>
     template<class Subscriber>
     void on_subscribe(const Subscriber& s) const {
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
         struct state_type
             : public std::enable_shared_from_this<state_type>
             , public values

--- a/Rx/v2/src/rxcpp/operators/rx-skip_last.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip_last.hpp
@@ -41,11 +41,11 @@ using skip_last_invalid_t = typename skip_last_invalid<AN...>::type;
 template<class T, class Observable, class Count>
 struct skip_last : public operator_base<T>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<Count> count_type;
+    using source_type = rxu::decay_t<Observable>;
+    using count_type = rxu::decay_t<Count>;
 
-    typedef std::queue<T> queue_type;
-    typedef typename queue_type::size_type queue_size_type;
+    using queue_type = std::queue<T>;
+    using queue_size_type = typename queue_type::size_type;
 
     struct values
     {
@@ -67,7 +67,7 @@ struct skip_last : public operator_base<T>
     template<class Subscriber>
     void on_subscribe(const Subscriber& s) const {
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
         struct state_type
             : public std::enable_shared_from_this<state_type>
             , public values

--- a/Rx/v2/src/rxcpp/operators/rx-skip_until.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip_until.hpp
@@ -48,10 +48,10 @@ using skip_until_invalid_t = typename skip_until_invalid<AN...>::type;
 template<class T, class Observable, class TriggerObservable, class Coordination>
 struct skip_until : public operator_base<T>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<TriggerObservable> trigger_source_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using source_type = rxu::decay_t<Observable>;
+    using trigger_source_type = rxu::decay_t<TriggerObservable>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
     struct values
     {
         values(source_type s, trigger_source_type t, coordination_type sf)
@@ -85,7 +85,7 @@ struct skip_until : public operator_base<T>
     template<class Subscriber>
     void on_subscribe(Subscriber s) const {
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
         struct state_type
             : public std::enable_shared_from_this<state_type>
             , public values

--- a/Rx/v2/src/rxcpp/operators/rx-skip_while.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip_while.hpp
@@ -41,8 +41,8 @@ using skip_while_invalid_t = typename skip_while_invalid<AN...>::type;
 template<class T, class Predicate>
 struct skip_while
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Predicate> test_type;
+    using source_value_type = rxu::decay_t<T>;
+    using test_type = rxu::decay_t<Predicate>;
     test_type test;
 
 
@@ -54,10 +54,10 @@ struct skip_while
     template<class Subscriber>
     struct skip_while_observer
     {
-        typedef skip_while_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = skip_while_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         test_type test;
         bool pass;

--- a/Rx/v2/src/rxcpp/operators/rx-subscribe_on.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-subscribe_on.hpp
@@ -44,9 +44,9 @@ using subscribe_on_invalid_t = typename subscribe_on_invalid<AN...>::type;
 template<class T, class Observable, class Coordination>
 struct subscribe_on : public operator_base<T>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using source_type = rxu::decay_t<Observable>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
     struct subscribe_on_values
     {
         ~subscribe_on_values()
@@ -75,7 +75,7 @@ struct subscribe_on : public operator_base<T>
     template<class Subscriber>
     void on_subscribe(Subscriber s) const {
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
         struct subscribe_on_state_type
             : public std::enable_shared_from_this<subscribe_on_state_type>
             , public subscribe_on_values

--- a/Rx/v2/src/rxcpp/operators/rx-switch_if_empty.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-switch_if_empty.hpp
@@ -41,8 +41,8 @@ using switch_if_empty_invalid_t = typename switch_if_empty_invalid<AN...>::type;
 template<class T, class BackupSource>
 struct switch_if_empty
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<BackupSource> backup_source_type;
+    using source_value_type = rxu::decay_t<T>;
+    using backup_source_type = rxu::decay_t<BackupSource>;
 
     backup_source_type backup;
 
@@ -54,10 +54,10 @@ struct switch_if_empty
     template<class Subscriber>
     struct switch_if_empty_observer
     {
-        typedef switch_if_empty_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = switch_if_empty_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
 
         dest_type dest;
         composite_subscription lifetime;

--- a/Rx/v2/src/rxcpp/operators/rx-switch_on_next.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-switch_on_next.hpp
@@ -45,18 +45,18 @@ struct switch_on_next
     //static_assert(is_observable<Observable>::value, "switch_on_next requires an observable");
     //static_assert(is_observable<T>::value, "switch_on_next requires an observable that contains observables");
 
-    typedef switch_on_next<T, Observable, Coordination> this_type;
+    using this_type = switch_on_next<T, Observable, Coordination>;
 
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Observable> source_type;
+    using source_value_type = rxu::decay_t<T>;
+    using source_type = rxu::decay_t<Observable>;
 
-    typedef typename source_type::source_operator_type source_operator_type;
+    using source_operator_type = typename source_type::source_operator_type;
 
-    typedef source_value_type collection_type;
-    typedef typename collection_type::value_type collection_value_type;
+    using collection_type = source_value_type;
+    using collection_value_type = typename collection_type::value_type;
 
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct values
     {
@@ -79,7 +79,7 @@ struct switch_on_next
     void on_subscribe(Subscriber scbr) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct switch_state_type
             : public std::enable_shared_from_this<switch_state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-take.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take.hpp
@@ -41,8 +41,8 @@ using take_invalid_t = typename take_invalid<AN...>::type;
 template<class T, class Observable, class Count>
 struct take : public operator_base<T>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<Count> count_type;
+    using source_type = rxu::decay_t<Observable>;
+    using count_type = rxu::decay_t<Count>;
     struct values
     {
         values(source_type s, count_type t)
@@ -73,7 +73,7 @@ struct take : public operator_base<T>
     template<class Subscriber>
     void on_subscribe(const Subscriber& s) const {
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
         struct state_type
             : public std::enable_shared_from_this<state_type>
             , public values

--- a/Rx/v2/src/rxcpp/operators/rx-take_last.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take_last.hpp
@@ -41,11 +41,11 @@ using take_last_invalid_t = typename take_last_invalid<AN...>::type;
 template<class T, class Observable, class Count>
 struct take_last : public operator_base<T>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<Count> count_type;
+    using source_type = rxu::decay_t<Observable>;
+    using count_type = rxu::decay_t<Count>;
 
-    typedef std::queue<T> queue_type;
-    typedef typename queue_type::size_type queue_size_type;
+    using queue_type = std::queue<T>;
+    using queue_size_type = typename queue_type::size_type;
 
     struct values
     {
@@ -67,7 +67,7 @@ struct take_last : public operator_base<T>
     template<class Subscriber>
     void on_subscribe(const Subscriber& s) const {
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
         struct state_type
             : public std::enable_shared_from_this<state_type>
             , public values

--- a/Rx/v2/src/rxcpp/operators/rx-take_until.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take_until.hpp
@@ -58,10 +58,10 @@ using take_until_invalid_t = typename take_until_invalid<AN...>::type;
 template<class T, class Observable, class TriggerObservable, class Coordination>
 struct take_until : public operator_base<T>
 {
-    typedef rxu::decay_t<Observable> source_type;
-    typedef rxu::decay_t<TriggerObservable> trigger_source_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using source_type = rxu::decay_t<Observable>;
+    using trigger_source_type = rxu::decay_t<TriggerObservable>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
     struct values
     {
         values(source_type s, trigger_source_type t, coordination_type sf)
@@ -95,7 +95,7 @@ struct take_until : public operator_base<T>
     template<class Subscriber>
     void on_subscribe(Subscriber s) const {
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
         struct take_until_state_type
             : public std::enable_shared_from_this<take_until_state_type>
             , public values

--- a/Rx/v2/src/rxcpp/operators/rx-take_while.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take_while.hpp
@@ -41,8 +41,8 @@ using take_while_invalid_t = typename take_while_invalid<AN...>::type;
 template<class T, class Predicate>
 struct take_while
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Predicate> test_type;
+    using source_value_type = rxu::decay_t<T>;
+    using test_type = rxu::decay_t<Predicate>;
     test_type test;
 
 
@@ -54,10 +54,10 @@ struct take_while
     template<class Subscriber>
     struct take_while_observer
     {
-        typedef take_while_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = take_while_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         test_type test;
 

--- a/Rx/v2/src/rxcpp/operators/rx-tap.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-tap.hpp
@@ -51,7 +51,7 @@ template<class T, class... ArgN>
 struct tap_observer_factory<T, std::tuple<ArgN...>>
 {
     using source_value_type = rxu::decay_t<T>;
-    using out_type = decltype(make_observer<source_value_type, rxcpp::detail::OnErrorIgnore>(*((ArgN*)nullptr)...));
+    using out_type = decltype(make_observer<source_value_type, rxcpp::detail::OnErrorIgnore>((std::declval<ArgN>())...));
     auto operator()(ArgN&&... an) -> out_type const {
         return make_observer<source_value_type, rxcpp::detail::OnErrorIgnore>(std::forward<ArgN>(an)...);
     }

--- a/Rx/v2/src/rxcpp/operators/rx-time_interval.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-time_interval.hpp
@@ -42,8 +42,8 @@ using time_interval_invalid_t = typename time_interval_invalid<AN...>::type;
 template<class T, class Coordination>
 struct time_interval
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
+    using source_value_type = rxu::decay_t<T>;
+    using coordination_type = rxu::decay_t<Coordination>;
 
     struct time_interval_values {
         time_interval_values(coordination_type c)
@@ -63,11 +63,11 @@ struct time_interval
     template<class Subscriber>
     struct time_interval_observer
     {
-        typedef time_interval_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
-        typedef rxsc::scheduler::clock_type::time_point time_point;
+        using this_type = time_interval_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
+        using time_point = rxsc::scheduler::clock_type::time_point;
         dest_type dest;
         coordination_type coord;
         mutable time_point last;

--- a/Rx/v2/src/rxcpp/operators/rx-timeout.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-timeout.hpp
@@ -51,10 +51,10 @@ using timeout_invalid_t = typename timeout_invalid<AN...>::type;
 template<class T, class Duration, class Coordination>
 struct timeout
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
-    typedef rxu::decay_t<Duration> duration_type;
+    using source_value_type = rxu::decay_t<T>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
+    using duration_type = rxu::decay_t<Duration>;
 
     struct timeout_values
     {
@@ -77,10 +77,10 @@ struct timeout
     template<class Subscriber>
     struct timeout_observer
     {
-        typedef timeout_observer<Subscriber> this_type;
-        typedef rxu::decay_t<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using this_type = timeout_observer<Subscriber>;
+        using value_type = rxu::decay_t<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
 
         struct timeout_subscriber_values : public timeout_values
         {
@@ -100,7 +100,8 @@ struct timeout
             rxsc::worker worker;
             mutable std::size_t index;
         };
-        typedef std::shared_ptr<timeout_subscriber_values> state_type;
+
+        using state_type = std::shared_ptr<timeout_subscriber_values>;
         state_type state;
 
         timeout_observer(composite_subscription cs, dest_type d, timeout_values v, coordinator_type c)

--- a/Rx/v2/src/rxcpp/operators/rx-timestamp.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-timestamp.hpp
@@ -41,8 +41,8 @@ using timestamp_invalid_t = typename timestamp_invalid<AN...>::type;
 template<class T, class Coordination>
 struct timestamp
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
+    using source_value_type = rxu::decay_t<T>;
+    using coordination_type = rxu::decay_t<Coordination>;
 
     struct timestamp_values {
         timestamp_values(coordination_type c)
@@ -62,10 +62,10 @@ struct timestamp
     template<class Subscriber>
     struct timestamp_observer
     {
-        typedef timestamp_observer<Subscriber> this_type;
-        typedef source_value_type value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = timestamp_observer<Subscriber>;
+        using value_type = source_value_type;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         coordination_type coord;
 

--- a/Rx/v2/src/rxcpp/operators/rx-window.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window.hpp
@@ -46,8 +46,8 @@ using window_invalid_t = typename window_invalid<AN...>::type;
 template<class T>
 struct window
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef observable<source_value_type> value_type;
+    using source_value_type = rxu::decay_t<T>;
+    using value_type = observable<source_value_type>;
 
     struct window_values
     {
@@ -70,10 +70,10 @@ struct window
     template<class Subscriber>
     struct window_observer : public window_values
     {
-        typedef window_observer<Subscriber> this_type;
-        typedef rxu::decay_t<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using this_type = window_observer<Subscriber>;
+        using value_type = rxu::decay_t<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
         dest_type dest;
         mutable int cursor;
         mutable std::deque<rxcpp::subjects::subject<T>> subj;

--- a/Rx/v2/src/rxcpp/operators/rx-window_time.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_time.hpp
@@ -58,11 +58,11 @@ using window_with_time_invalid_t = typename window_with_time_invalid<AN...>::typ
 template<class T, class Duration, class Coordination>
 struct window_with_time
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef observable<source_value_type> value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
-    typedef rxu::decay_t<Duration> duration_type;
+    using source_value_type = rxu::decay_t<T>;
+    using value_type = observable<source_value_type>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
+    using duration_type = rxu::decay_t<Duration>;
 
     struct window_with_time_values
     {
@@ -86,10 +86,10 @@ struct window_with_time
     template<class Subscriber>
     struct window_with_time_observer
     {
-        typedef window_with_time_observer<Subscriber> this_type;
-        typedef rxu::decay_t<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using this_type = window_with_time_observer<Subscriber>;
+        using value_type = rxu::decay_t<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
 
         struct window_with_time_subscriber_values : public window_with_time_values
         {

--- a/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
@@ -48,11 +48,11 @@ using window_with_time_or_count_invalid_t = typename window_with_time_or_count_i
 template<class T, class Duration, class Coordination>
 struct window_with_time_or_count
 {
-    typedef rxu::decay_t<T> source_value_type;
-    typedef observable<source_value_type> value_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
-    typedef rxu::decay_t<Duration> duration_type;
+    using source_value_type = rxu::decay_t<T>;
+    using value_type = observable<source_value_type>;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
+    using duration_type = rxu::decay_t<Duration>;
 
     struct window_with_time_or_count_values
     {
@@ -76,10 +76,10 @@ struct window_with_time_or_count
     template<class Subscriber>
     struct window_with_time_or_count_observer
     {
-        typedef window_with_time_or_count_observer<Subscriber> this_type;
-        typedef rxu::decay_t<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using this_type = window_with_time_or_count_observer<Subscriber>;
+        using value_type = rxu::decay_t<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
 
         struct window_with_time_or_count_subscriber_values : public window_with_time_or_count_values
         {
@@ -101,7 +101,8 @@ struct window_with_time_or_count
             mutable int subj_id;
             mutable rxcpp::subjects::subject<T> subj;
         };
-        typedef std::shared_ptr<window_with_time_or_count_subscriber_values> state_type;
+
+        using state_type = std::shared_ptr<window_with_time_or_count_subscriber_values>;
         state_type state;
 
         window_with_time_or_count_observer(composite_subscription cs, dest_type d, window_with_time_or_count_values v, coordinator_type c)

--- a/Rx/v2/src/rxcpp/operators/rx-window_toggle.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_toggle.hpp
@@ -49,7 +49,7 @@ using window_toggle_invalid_t = typename window_toggle_invalid<AN...>::type;
 template<class T, class Openings, class ClosingSelector, class Coordination>
 struct window_toggle
 {
-    typedef window_toggle<T, Openings, ClosingSelector, Coordination> this_type;
+    using this_type = window_toggle<T, Openings, ClosingSelector, Coordination>;
 
     using source_value_type = rxu::decay_t<T>;
     using coordination_type = rxu::decay_t<Coordination>;
@@ -82,10 +82,10 @@ struct window_toggle
     template<class Subscriber>
     struct window_toggle_observer
     {
-        typedef window_toggle_observer<Subscriber> this_type;
-        typedef rxu::decay_t<T> value_type;
-        typedef rxu::decay_t<Subscriber> dest_type;
-        typedef observer<T, this_type> observer_type;
+        using this_type = window_toggle_observer<Subscriber>;
+        using value_type = rxu::decay_t<T>;
+        using dest_type = rxu::decay_t<Subscriber>;
+        using observer_type = observer<T, this_type>;
 
         struct window_toggle_subscriber_values : public window_toggle_values
         {

--- a/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
@@ -77,10 +77,10 @@ struct invalid_with_latest_from_selector {
 };
 
 template<class Selector, class... ObservableN>
-struct is_with_latest_from_selector : public std::conditional<
+struct is_with_latest_from_selector : public std::conditional_t<
     is_with_latest_from_selector_check<Selector, ObservableN...>::value, 
     is_with_latest_from_selector_check<Selector, ObservableN...>, 
-    invalid_with_latest_from_selector<Selector, ObservableN...>>::type {
+    invalid_with_latest_from_selector<Selector, ObservableN...>> {
 };
 
 template<class Selector, class... ON>

--- a/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
@@ -68,7 +68,7 @@ struct is_with_latest_from_selector_check {
 
     using type = decltype(check<selector_type, rxu::decay_t<ObservableN>...>(0));
 
-    static const bool value = !std::is_same<type, tag_not_valid>::value;
+    static const bool value = !std::is_same_v<type, tag_not_valid>;
 };
 
 template<class Selector, class... ObservableN>

--- a/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
@@ -62,7 +62,7 @@ struct is_with_latest_from_selector_check {
 
     struct tag_not_valid;
     template<class CS, class... CON>
-    static auto check(int) -> decltype((*(CS*)nullptr)((*(typename CON::value_type*)nullptr)...));
+    static auto check(int) -> decltype(std::declval<CS>()((std::declval<typename CON::value_type>())...));
     template<class CS, class... CON>
     static tag_not_valid check(...);
 

--- a/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
@@ -58,7 +58,7 @@ using with_latest_from_invalid_t = typename with_latest_from_invalid<AN...>::typ
 
 template<class Selector, class... ObservableN>
 struct is_with_latest_from_selector_check {
-    typedef rxu::decay_t<Selector> selector_type;
+    using selector_type = rxu::decay_t<Selector>;
 
     struct tag_not_valid;
     template<class CS, class... CON>
@@ -89,29 +89,29 @@ using result_with_latest_from_selector_t = typename is_with_latest_from_selector
 template<class Coordination, class Selector, class... ObservableN>
 struct with_latest_from_traits {
 
-    typedef std::tuple<ObservableN...> tuple_source_type;
-    typedef std::tuple<rxu::detail::maybe<typename ObservableN::value_type>...> tuple_source_value_type;
+    using tuple_source_type = std::tuple<ObservableN...>;
+    using tuple_source_value_type = std::tuple<rxu::detail::maybe < typename ObservableN::value_type>...>;
 
-    typedef rxu::decay_t<Selector> selector_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
+    using selector_type = rxu::decay_t<Selector>;
+    using coordination_type = rxu::decay_t<Coordination>;
 
-    typedef typename is_with_latest_from_selector<selector_type, ObservableN...>::type value_type;
+    using value_type = typename is_with_latest_from_selector<selector_type, ObservableN...>::type;
 };
 
 template<class Coordination, class Selector, class... ObservableN>
 struct with_latest_from : public operator_base<rxu::value_type_t<with_latest_from_traits<Coordination, Selector, ObservableN...>>>
 {
-    typedef with_latest_from<Coordination, Selector, ObservableN...> this_type;
+    using this_type = with_latest_from<Coordination, Selector, ObservableN...>;
 
-    typedef with_latest_from_traits<Coordination, Selector, ObservableN...> traits;
+    using traits = with_latest_from_traits<Coordination, Selector, ObservableN...>;
 
-    typedef typename traits::tuple_source_type tuple_source_type;
-    typedef typename traits::tuple_source_value_type tuple_source_value_type;
+    using tuple_source_type = typename traits::tuple_source_type;
+    using tuple_source_value_type = typename traits::tuple_source_value_type;
 
-    typedef typename traits::selector_type selector_type;
+    using selector_type = typename traits::selector_type;
 
-    typedef typename traits::coordination_type coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = typename traits::coordination_type;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct values
     {
@@ -135,7 +135,7 @@ struct with_latest_from : public operator_base<rxu::value_type_t<with_latest_fro
     template<int Index, class State>
     void subscribe_one(std::shared_ptr<State> state) const {
 
-        typedef typename std::tuple_element<Index, tuple_source_type>::type::value_type source_value_type;
+        using source_value_type = typename std::tuple_element<Index, tuple_source_type>::type::value_type;
 
         composite_subscription innercs;
 
@@ -200,7 +200,7 @@ struct with_latest_from : public operator_base<rxu::value_type_t<with_latest_fro
     void on_subscribe(Subscriber scbr) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct with_latest_from_state_type
             : public std::enable_shared_from_this<with_latest_from_state_type>

--- a/Rx/v2/src/rxcpp/operators/rx-zip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-zip.hpp
@@ -103,7 +103,7 @@ struct is_zip_selector_check {
 
     using type = decltype(check<selector_type, rxu::decay_t<ObservableN>...>(0));
 
-    static const bool value = !std::is_same<type, tag_not_valid>::value;
+    static const bool value = !std::is_same_v<type, tag_not_valid>;
 };
 
 template<class Selector, class... ObservableN>

--- a/Rx/v2/src/rxcpp/operators/rx-zip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-zip.hpp
@@ -112,10 +112,10 @@ struct invalid_zip_selector {
 };
 
 template<class Selector, class... ObservableN>
-struct is_zip_selector : public std::conditional<
+struct is_zip_selector : public std::conditional_t<
     is_zip_selector_check<Selector, ObservableN...>::value, 
     is_zip_selector_check<Selector, ObservableN...>, 
-    invalid_zip_selector<Selector, ObservableN...>>::type {
+    invalid_zip_selector<Selector, ObservableN...>> {
 };
 
 template<class Selector, class... ON>

--- a/Rx/v2/src/rxcpp/operators/rx-zip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-zip.hpp
@@ -97,7 +97,7 @@ struct is_zip_selector_check {
 
     struct tag_not_valid;
     template<class CS, class... CON>
-    static auto check(int) -> decltype((*(CS*)nullptr)((*(typename CON::value_type*)nullptr)...));
+    static auto check(int) -> decltype(std::declval<CS>()((std::declval<typename CON::value_type>())...));
     template<class CS, class... CON>
     static tag_not_valid check(...);
 

--- a/Rx/v2/src/rxcpp/operators/rx-zip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-zip.hpp
@@ -93,7 +93,7 @@ using zip_invalid_t = typename zip_invalid<AN...>::type;
 
 template<class Selector, class... ObservableN>
 struct is_zip_selector_check {
-    typedef rxu::decay_t<Selector> selector_type;
+    using selector_type = rxu::decay_t<Selector>;
 
     struct tag_not_valid;
     template<class CS, class... CON>
@@ -123,29 +123,29 @@ using result_zip_selector_t = typename is_zip_selector<Selector, ON...>::type;
 
 template<class Coordination, class Selector, class... ObservableN>
 struct zip_traits {
-    typedef std::tuple<rxu::decay_t<ObservableN>...> tuple_source_type;
-    typedef std::tuple<zip_source_state<ObservableN>...> tuple_source_values_type;
+    using tuple_source_type = std::tuple<rxu::decay_t < ObservableN>...>;
+    using tuple_source_values_type = std::tuple<zip_source_state<ObservableN>...>;
 
-    typedef rxu::decay_t<Selector> selector_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
+    using selector_type = rxu::decay_t<Selector>;
+    using coordination_type = rxu::decay_t<Coordination>;
 
-    typedef typename is_zip_selector<selector_type, ObservableN...>::type value_type;
+    using value_type = typename is_zip_selector<selector_type, ObservableN...>::type;
 };
 
 template<class Coordination, class Selector, class... ObservableN>
 struct zip : public operator_base<rxu::value_type_t<zip_traits<Coordination, Selector, ObservableN...>>>
 {
-    typedef zip<Coordination, Selector, ObservableN...> this_type;
+    using this_type = zip<Coordination, Selector, ObservableN...>;
 
-    typedef zip_traits<Coordination, Selector, ObservableN...> traits;
+    using traits = zip_traits<Coordination, Selector, ObservableN...>;
 
-    typedef typename traits::tuple_source_type tuple_source_type;
-    typedef typename traits::tuple_source_values_type tuple_source_values_type;
+    using tuple_source_type = typename traits::tuple_source_type;
+    using tuple_source_values_type = typename traits::tuple_source_values_type;
 
-    typedef typename traits::selector_type selector_type;
+    using selector_type = typename traits::selector_type;
 
-    typedef typename traits::coordination_type coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = typename traits::coordination_type;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct values
     {
@@ -169,7 +169,7 @@ struct zip : public operator_base<rxu::value_type_t<zip_traits<Coordination, Sel
     template<int Index, class State>
     void subscribe_one(std::shared_ptr<State> state) const {
 
-        typedef typename std::tuple_element<Index, tuple_source_type>::type::value_type source_value_type;
+        using source_value_type = typename std::tuple_element<Index, tuple_source_type>::type::value_type;
 
         composite_subscription innercs;
 
@@ -232,7 +232,7 @@ struct zip : public operator_base<rxu::value_type_t<zip_traits<Coordination, Sel
     void on_subscribe(Subscriber scbr) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef Subscriber output_type;
+        using output_type = Subscriber;
 
         struct zip_state_type
             : public std::enable_shared_from_this<zip_state_type>

--- a/Rx/v2/src/rxcpp/rx-composite_exception.hpp
+++ b/Rx/v2/src/rxcpp/rx-composite_exception.hpp
@@ -11,7 +11,7 @@ namespace rxcpp {
 
 struct composite_exception : std::exception {
 
-    typedef std::vector<rxu::error_ptr> exception_values;
+    using exception_values = std::vector<rxu::error_ptr>;
 
     virtual const char *what() const RXCPP_NOEXCEPT override {
         return "rxcpp composite exception";

--- a/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
@@ -16,7 +16,7 @@ struct has_on_connect
 {
     struct not_void {};
     template<class CT>
-    static auto check(int) -> decltype((*(CT*)nullptr).on_connect(composite_subscription()));
+    static auto check(int) -> decltype(std::declval<CT>().on_connect(composite_subscription()));
     template<class CT>
     static not_void check(...);
 
@@ -145,7 +145,7 @@ public:
     ///
     template<class OperatorFactory>
     auto op(OperatorFactory&& of) const
-        -> decltype(of(*(const this_type*)nullptr)) {
+        -> decltype(of(std::declval<const this_type>())) {
         return      of(*this);
         static_assert(is_operator_factory_for<this_type, OperatorFactory>::value, "Function passed for op() must have the signature Result(SourceObservable)");
     }
@@ -167,7 +167,7 @@ public:
     template<class... AN>
     auto ref_count(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(ref_count_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(ref_count_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(ref_count_tag{},                *this, std::forward<AN>(an)...);
@@ -178,7 +178,7 @@ public:
     template<class... AN>
     auto connect_forever(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(connect_forever_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(connect_forever_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(connect_forever_tag{},                *this, std::forward<AN>(an)...);

--- a/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
@@ -70,8 +70,7 @@ public:
         : dynamic_observable<T>(sof)
         , state(std::make_shared<state_type>())
     {
-        construct(std::move(sof),
-                  typename std::conditional<is_dynamic_observable<SOF>::value, tag_dynamic_observable, rxs::tag_source>::type());
+        construct(std::move(sof), typename std::conditional_t<is_dynamic_observable<SOF>::value, tag_dynamic_observable, rxs::tag_source>());
     }
 
     template<class SF, class CF>

--- a/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
@@ -21,7 +21,7 @@ struct has_on_connect
     static not_void check(...);
 
     using detail_result = decltype(check<T>(0));
-    static const bool value = std::is_same<detail_result, void>::value;
+    static const bool value = std::is_same_v<detail_result, void>;
 };
 
 }

--- a/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
@@ -20,7 +20,7 @@ struct has_on_connect
     template<class CT>
     static not_void check(...);
 
-    typedef decltype(check<T>(0)) detail_result;
+    using detail_result = decltype(check<T>(0));
     static const bool value = std::is_same<detail_result, void>::value;
 };
 
@@ -33,7 +33,7 @@ class dynamic_connectable_observable
     struct state_type
         : public std::enable_shared_from_this<state_type>
     {
-        typedef std::function<void(composite_subscription)> onconnect_type;
+        using onconnect_type = std::function<void(composite_subscription)>;
 
         onconnect_type on_connect;
     };
@@ -59,7 +59,7 @@ class dynamic_connectable_observable
 
 public:
 
-    typedef tag_dynamic_observable dynamic_observable_tag;
+    using dynamic_observable_tag = tag_dynamic_observable;
 
     dynamic_connectable_observable()
     {
@@ -105,14 +105,14 @@ template<class T, class SourceOperator>
 class connectable_observable
     : public observable<T, SourceOperator>
 {
-    typedef connectable_observable<T, SourceOperator> this_type;
-    typedef observable<T, SourceOperator> base_type;
-    typedef rxu::decay_t<SourceOperator> source_operator_type;
+    using this_type = connectable_observable<T, SourceOperator>;
+    using base_type = observable<T, SourceOperator>;
+    using source_operator_type = rxu::decay_t<SourceOperator>;
 
     static_assert(detail::has_on_connect<source_operator_type>::value, "inner must have on_connect method void(composite_subscription)");
 
 public:
-    typedef tag_connectable_observable observable_tag;
+    using observable_tag = tag_connectable_observable;
 
     connectable_observable()
     {

--- a/Rx/v2/src/rxcpp/rx-coordination.hpp
+++ b/Rx/v2/src/rxcpp/rx-coordination.hpp
@@ -74,9 +74,9 @@ public:
     template<class T>
     struct get
     {
-        using type = typename std::conditional<rxsc::detail::is_action_function<T>::value, get_action_function<T>,
-                typename std::conditional<is_observable<T>::value, get_observable<T>,
-                        typename std::conditional<is_subscriber<T>::value, get_subscriber<T>, not_supported>::type>::type>::type::type;
+        using type = typename std::conditional_t<rxsc::detail::is_action_function<T>::value, get_action_function<T>,
+                typename std::conditional_t<is_observable<T>::value, get_observable<T>,
+                        typename std::conditional_t<is_subscriber<T>::value, get_subscriber<T>, not_supported>>>::type;
     };
 
     coordinator(Input i) : input(i) {}

--- a/Rx/v2/src/rxcpp/rx-coordination.hpp
+++ b/Rx/v2/src/rxcpp/rx-coordination.hpp
@@ -53,19 +53,19 @@ private:
     template<class Observable>
     struct get_observable
     {
-        typedef decltype((*(input_type*)nullptr).in((*(Observable*)nullptr))) type;
+        using type = decltype(std::declval<input_type>().in(std::declval<Observable>()));
     };
 
     template<class Subscriber>
     struct get_subscriber
     {
-        typedef decltype((*(input_type*)nullptr).out((*(Subscriber*)nullptr))) type;
+        using type = decltype(std::declval<input_type>().out(std::declval<Subscriber>()));
     };
 
     template<class F>
     struct get_action_function
     {
-        typedef decltype((*(input_type*)nullptr).act((*(F*)nullptr))) type;
+        using type = decltype(std::declval<input_type>().act(std::declval<F>()));
     };
 
 public:

--- a/Rx/v2/src/rxcpp/rx-coordination.hpp
+++ b/Rx/v2/src/rxcpp/rx-coordination.hpp
@@ -10,7 +10,7 @@
 namespace rxcpp {
 
 struct tag_coordinator {};
-struct coordinator_base {typedef tag_coordinator coordinator_tag;};
+struct coordinator_base { using coordinator_tag = tag_coordinator; };
 
 template<class T, class C = rxu::types_checked>
 struct is_coordinator : public std::false_type {};
@@ -20,7 +20,7 @@ struct is_coordinator<T, typename rxu::types_checked_from<typename T::coordinato
     : public std::is_convertible<typename T::coordinator_tag*, tag_coordinator*> {};
 
 struct tag_coordination {};
-struct coordination_base {typedef tag_coordination coordination_tag;};
+struct coordination_base { using coordination_tag = tag_coordination; };
 
 namespace detail {
 
@@ -45,10 +45,10 @@ template<class Input>
 class coordinator : public coordinator_base
 {
 public:
-    typedef Input input_type;
+    using input_type = Input;
 
 private:
-    struct not_supported {typedef not_supported type;};
+    struct not_supported { using type = not_supported; };
 
     template<class Observable>
     struct get_observable
@@ -74,10 +74,9 @@ public:
     template<class T>
     struct get
     {
-        typedef typename std::conditional<
-            rxsc::detail::is_action_function<T>::value, get_action_function<T>, typename std::conditional<
-            is_observable<T>::value, get_observable<T>, typename std::conditional<
-            is_subscriber<T>::value, get_subscriber<T>, not_supported>::type>::type>::type::type type;
+        using type = typename std::conditional<rxsc::detail::is_action_function<T>::value, get_action_function<T>,
+                typename std::conditional<is_observable<T>::value, get_observable<T>,
+                        typename std::conditional<is_subscriber<T>::value, get_subscriber<T>, not_supported>::type>::type>::type::type;
     };
 
     coordinator(Input i) : input(i) {}
@@ -155,7 +154,7 @@ public:
 
     explicit identity_one_worker(rxsc::scheduler sc) : factory(sc) {}
 
-    typedef coordinator<input_type> coordinator_type;
+    using coordinator_type = coordinator<input_type>;
 
     inline rxsc::scheduler::clock_type::time_point now() const {
         return factory.now();
@@ -208,10 +207,10 @@ class serialize_one_worker : public coordination_base
     template<class Observer>
     struct serialize_observer
     {
-        typedef serialize_observer<Observer> this_type;
-        typedef rxu::decay_t<Observer> dest_type;
-        typedef typename dest_type::value_type value_type;
-        typedef observer<value_type, this_type> observer_type;
+        using this_type = serialize_observer<Observer>;
+        using dest_type = rxu::decay_t<Observer>;
+        using value_type = typename dest_type::value_type;
+        using observer_type = observer<value_type, this_type>;
         dest_type dest;
         std::shared_ptr<std::mutex> lock;
 
@@ -284,7 +283,7 @@ public:
 
     explicit serialize_one_worker(rxsc::scheduler sc) : factory(sc) {}
 
-    typedef coordinator<input_type> coordinator_type;
+    using coordinator_type = coordinator<input_type>;
 
     inline rxsc::scheduler::clock_type::time_point now() const {
         return factory.now();

--- a/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
@@ -21,7 +21,7 @@ struct has_on_get_key_for
     static not_void check(...);
 
     using detail_result = decltype(check<Source>(0));
-    static const bool value = std::is_same<detail_result, rxu::decay_t<K>>::value;
+    static const bool value = std::is_same_v<detail_result, rxu::decay_t<K>>;
 };
 
 }

--- a/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
@@ -20,7 +20,7 @@ struct has_on_get_key_for
     template<class CS>
     static not_void check(...);
 
-    typedef decltype(check<Source>(0)) detail_result;
+    using detail_result = decltype(check<Source>(0));
     static const bool value = std::is_same<detail_result, rxu::decay_t<K>>::value;
 };
 
@@ -31,14 +31,14 @@ class dynamic_grouped_observable
     : public dynamic_observable<T>
 {
 public:
-    typedef rxu::decay_t<K> key_type;
-    typedef tag_dynamic_grouped_observable dynamic_observable_tag;
+    using key_type = rxu::decay_t<K>;
+    using dynamic_observable_tag = tag_dynamic_grouped_observable;
 
 private:
     struct state_type
         : public std::enable_shared_from_this<state_type>
     {
-        typedef std::function<key_type()> ongetkey_type;
+        using ongetkey_type = std::function<key_type()>;
 
         ongetkey_type on_get_key;
     };
@@ -121,15 +121,15 @@ template<class K, class T, class SourceOperator>
 class grouped_observable
     : public observable<T, SourceOperator>
 {
-    typedef grouped_observable<K, T, SourceOperator> this_type;
-    typedef observable<T, SourceOperator> base_type;
-    typedef rxu::decay_t<SourceOperator> source_operator_type;
+    using this_type = grouped_observable<K, T, SourceOperator>;
+    using base_type = observable<T, SourceOperator>;
+    using source_operator_type = rxu::decay_t<SourceOperator>;
 
     static_assert(detail::has_on_get_key_for<K, source_operator_type>::value, "inner must have on_get_key method key_type()");
 
 public:
-    typedef rxu::decay_t<K> key_type;
-    typedef tag_grouped_observable observable_tag;
+    using key_type = rxu::decay_t<K>;
+    using observable_tag = tag_grouped_observable;
 
     grouped_observable()
     {

--- a/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
@@ -76,8 +76,7 @@ public:
         : dynamic_observable<T>(sof)
         , state(std::make_shared<state_type>())
     {
-        construct(std::move(sof),
-                  typename std::conditional<is_dynamic_grouped_observable<SOF>::value, tag_dynamic_grouped_observable, rxs::tag_source>::type());
+        construct(std::move(sof), typename std::conditional_t<is_dynamic_grouped_observable<SOF>::value, tag_dynamic_grouped_observable, rxs::tag_source>());
     }
 
     template<class SF, class CF>

--- a/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
@@ -16,7 +16,7 @@ struct has_on_get_key_for
 {
     struct not_void {};
     template<class CS>
-    static auto check(int) -> decltype((*(CS*)nullptr).on_get_key());
+    static auto check(int) -> decltype(std::declval<CS>().on_get_key());
     template<class CS>
     static not_void check(...);
 

--- a/Rx/v2/src/rxcpp/rx-notification.hpp
+++ b/Rx/v2/src/rxcpp/rx-notification.hpp
@@ -46,8 +46,8 @@ template<typename T>
 struct notification_base
     : public std::enable_shared_from_this<notification_base<T>>
 {
-    typedef subscriber<T> observer_type;
-    typedef std::shared_ptr<notification_base<T>> type;
+    using observer_type = subscriber<T>;
+    using type = std::shared_ptr<notification_base<T>>;
 
     virtual ~notification_base() {}
 
@@ -116,11 +116,11 @@ bool equals(const T&, const T&, ...) {
 template<typename T>
 struct notification
 {
-    typedef typename detail::notification_base<T>::type type;
-    typedef typename detail::notification_base<T>::observer_type observer_type;
+    using type = typename detail::notification_base<T>::type;
+    using observer_type = typename detail::notification_base<T>::observer_type;
 
 private:
-    typedef detail::notification_base<T> base;
+    using base = detail::notification_base<T>;
 
     struct on_next_notification : public base {
         on_next_notification(T&& value) : value(std::move(value)) {}

--- a/Rx/v2/src/rxcpp/rx-notification.hpp
+++ b/Rx/v2/src/rxcpp/rx-notification.hpp
@@ -230,7 +230,7 @@ public:
     template<typename Exception>
     static type on_error(Exception&& e) {
         return make_on_error(typename std::conditional<
-            std::is_same<rxu::decay_t<Exception>, rxu::error_ptr>::value,
+            std::is_same_v<rxu::decay_t<Exception>, rxu::error_ptr>,
                 exception_ptr_tag, exception_tag>::type(),
             std::forward<Exception>(e));
     }

--- a/Rx/v2/src/rxcpp/rx-notification.hpp
+++ b/Rx/v2/src/rxcpp/rx-notification.hpp
@@ -229,10 +229,7 @@ public:
 
     template<typename Exception>
     static type on_error(Exception&& e) {
-        return make_on_error(typename std::conditional<
-            std::is_same_v<rxu::decay_t<Exception>, rxu::error_ptr>,
-                exception_ptr_tag, exception_tag>::type(),
-            std::forward<Exception>(e));
+        return make_on_error(typename std::conditional_t<std::is_same_v<rxu::decay_t<Exception>, rxu::error_ptr>, exception_ptr_tag, exception_tag>(), std::forward<Exception>(e));
     }
 };
 

--- a/Rx/v2/src/rxcpp/rx-observable-fwd.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable-fwd.hpp
@@ -14,8 +14,7 @@ class dynamic_observable;
 
 template<
     class T = void,
-    class SourceObservable = typename std::conditional<std::is_same_v<T, void>,
-        void, dynamic_observable<T>>::type>
+    class SourceObservable = typename std::conditional_t<std::is_same_v<T, void>, void, dynamic_observable<T>>>
 class observable;
 
 template<class T, class Source>

--- a/Rx/v2/src/rxcpp/rx-observable-fwd.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable-fwd.hpp
@@ -14,7 +14,7 @@ class dynamic_observable;
 
 template<
     class T = void,
-    class SourceObservable = typename std::conditional<std::is_same<T, void>::value,
+    class SourceObservable = typename std::conditional<std::is_same_v<T, void>,
         void, dynamic_observable<T>>::type>
 class observable;
 

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -75,7 +75,7 @@ public:
         : state(std::make_shared<state_type>())
     {
         construct(std::forward<SOF>(sof),
-                  typename std::conditional<rxs::is_source<SOF>::value || rxo::is_operator<SOF>::value, rxs::tag_source, tag_function>::type());
+                  typename std::conditional_t<rxs::is_source<SOF>::value || rxo::is_operator<SOF>::value, rxs::tag_source, tag_function>());
     }
 
     void on_subscribe(subscriber<T> o) const {

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -22,7 +22,7 @@ struct has_on_subscribe_for
 {
     struct not_void {};
     template<class CS, class CT>
-    static auto check(int) -> decltype((*(CT*)nullptr).on_subscribe(*(CS*)nullptr));
+    static auto check(int) -> decltype(std::declval<CT>().on_subscribe(std::declval<CS>()));
     template<class CS, class CT>
     static not_void check(...);
 
@@ -579,7 +579,7 @@ public:
     template<class... AN>
     auto ref_count(AN... an) const // ref_count(ConnectableObservable&&)
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(ref_count_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(ref_count_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(ref_count_tag{},                *this, std::forward<AN>(an)...);
@@ -602,7 +602,7 @@ public:
     ///
     template<class OperatorFactory>
     auto op(OperatorFactory&& of) const
-        -> decltype(of(*(const this_type*)nullptr)) {
+        -> decltype(of(std::declval<const this_type>())) {
         return      of(*this);
         static_assert(is_operator_factory_for<this_type, OperatorFactory>::value, "Function passed for op() must have the signature Result(SourceObservable)");
     }
@@ -655,7 +655,7 @@ public:
     template<class... AN>
     auto all(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(all_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(all_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(all_tag{},                *this, std::forward<AN>(an)...);
@@ -666,7 +666,7 @@ public:
     template<class... AN>
     auto is_empty(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(is_empty_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(is_empty_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(is_empty_tag{},                *this, std::forward<AN>(an)...);
@@ -677,7 +677,7 @@ public:
     template<class... AN>
     auto any(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(any_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(any_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(any_tag{},                *this, std::forward<AN>(an)...);
@@ -688,7 +688,7 @@ public:
     template<class... AN>
     auto exists(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(exists_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(exists_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(exists_tag{},                *this, std::forward<AN>(an)...);
@@ -699,7 +699,7 @@ public:
     template<class... AN>
     auto contains(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(contains_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(contains_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(contains_tag{},                *this, std::forward<AN>(an)...);
@@ -710,7 +710,7 @@ public:
     template<class... AN>
     auto filter(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(filter_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(filter_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(filter_tag{}, *this,                std::forward<AN>(an)...);
@@ -721,7 +721,7 @@ public:
     template<class... AN>
     auto switch_if_empty(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(switch_if_empty_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(switch_if_empty_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(switch_if_empty_tag{},                *this, std::forward<AN>(an)...);
@@ -732,7 +732,7 @@ public:
     template<class... AN>
     auto default_if_empty(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(default_if_empty_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(default_if_empty_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(default_if_empty_tag{},                *this, std::forward<AN>(an)...);
@@ -743,7 +743,7 @@ public:
     template<class... AN>
     auto sequence_equal(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(sequence_equal_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(sequence_equal_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(sequence_equal_tag{},                *this, std::forward<AN>(an)...);
@@ -754,7 +754,7 @@ public:
     template<class... AN>
     auto tap(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(tap_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(tap_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(tap_tag{},                *this, std::forward<AN>(an)...);
@@ -765,7 +765,7 @@ public:
     template<class... AN>
     auto time_interval(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(time_interval_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(time_interval_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(time_interval_tag{},                *this, std::forward<AN>(an)...);
@@ -776,7 +776,7 @@ public:
     template<class... AN>
     auto timeout(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(timeout_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(timeout_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(timeout_tag{},                *this, std::forward<AN>(an)...);
@@ -787,7 +787,7 @@ public:
     template<class... AN>
     auto timestamp(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(timestamp_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(timestamp_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(timestamp_tag{},                *this, std::forward<AN>(an)...);
@@ -798,7 +798,7 @@ public:
     template<class... AN>
     auto finally(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(finally_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(finally_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(finally_tag{},                *this, std::forward<AN>(an)...);
@@ -809,7 +809,7 @@ public:
     template<class... AN>
     auto on_error_resume_next(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(on_error_resume_next_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(on_error_resume_next_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(on_error_resume_next_tag{},                *this, std::forward<AN>(an)...);
@@ -820,7 +820,7 @@ public:
     template<class... AN>
     auto switch_on_error(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(on_error_resume_next_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(on_error_resume_next_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(on_error_resume_next_tag{},                *this, std::forward<AN>(an)...);
@@ -831,7 +831,7 @@ public:
     template<class... AN>
     auto map(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(map_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(map_tag{},                *this, std::forward<AN>(an)...);
@@ -842,7 +842,7 @@ public:
     template<class... AN>
     auto transform(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(map_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(map_tag{},                *this, std::forward<AN>(an)...);
@@ -853,7 +853,7 @@ public:
     template<class... AN>
     auto debounce(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(debounce_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(debounce_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(debounce_tag{},                *this, std::forward<AN>(an)...);
@@ -864,7 +864,7 @@ public:
     template<class... AN>
     auto delay(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(delay_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(delay_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(delay_tag{},                *this, std::forward<AN>(an)...);
@@ -875,7 +875,7 @@ public:
     template<class... AN>
     auto distinct(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(distinct_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(distinct_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(distinct_tag{},                *this, std::forward<AN>(an)...);
@@ -886,7 +886,7 @@ public:
     template<class... AN>
     auto distinct_until_changed(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(distinct_until_changed_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(distinct_until_changed_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(distinct_until_changed_tag{},                *this, std::forward<AN>(an)...);
@@ -897,7 +897,7 @@ public:
     template<class... AN>
     auto element_at(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(element_at_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(element_at_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(element_at_tag{},                *this, std::forward<AN>(an)...);
@@ -908,7 +908,7 @@ public:
     template<class... AN>
     auto window(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(window_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(window_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(window_tag{},                *this, std::forward<AN>(an)...);
@@ -919,7 +919,7 @@ public:
     template<class... AN>
     auto window_with_time(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(window_with_time_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(window_with_time_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(window_with_time_tag{},                *this, std::forward<AN>(an)...);
@@ -930,7 +930,7 @@ public:
     template<class... AN>
     auto window_with_time_or_count(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(window_with_time_or_count_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(window_with_time_or_count_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(window_with_time_or_count_tag{},                *this, std::forward<AN>(an)...);
@@ -941,7 +941,7 @@ public:
     template<class... AN>
     auto window_toggle(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(window_toggle_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(window_toggle_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(window_toggle_tag{},                *this, std::forward<AN>(an)...);
@@ -952,7 +952,7 @@ public:
     template<class... AN>
     auto buffer(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(buffer_count_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(buffer_count_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(buffer_count_tag{},                *this, std::forward<AN>(an)...);
@@ -963,7 +963,7 @@ public:
     template<class... AN>
     auto buffer_with_time(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(buffer_with_time_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(buffer_with_time_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(buffer_with_time_tag{},                *this, std::forward<AN>(an)...);
@@ -974,7 +974,7 @@ public:
     template<class... AN>
     auto buffer_with_time_or_count(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(buffer_with_time_or_count_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(buffer_with_time_or_count_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(buffer_with_time_or_count_tag{},                *this, std::forward<AN>(an)...);
@@ -985,7 +985,7 @@ public:
     template<class... AN>
     auto switch_on_next(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(switch_on_next_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(switch_on_next_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(switch_on_next_tag{},                *this, std::forward<AN>(an)...);
@@ -996,7 +996,7 @@ public:
     template<class... AN>
     auto merge(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(merge_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(merge_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(merge_tag{},                *this, std::forward<AN>(an)...);
@@ -1007,7 +1007,7 @@ public:
     template<class... AN>
     auto merge_delay_error(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(merge_delay_error_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(merge_delay_error_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
             return      observable_member(merge_delay_error_tag{},                *this, std::forward<AN>(an)...);
@@ -1018,7 +1018,7 @@ public:
     template<class... AN>
     auto amb(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(amb_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(amb_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(amb_tag{},                *this, std::forward<AN>(an)...);
@@ -1029,7 +1029,7 @@ public:
     template<class... AN>
     auto flat_map(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(flat_map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(flat_map_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(flat_map_tag{},                *this, std::forward<AN>(an)...);
@@ -1040,7 +1040,7 @@ public:
     template<class... AN>
     auto merge_transform(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(flat_map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(flat_map_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(flat_map_tag{},                *this, std::forward<AN>(an)...);
@@ -1051,7 +1051,7 @@ public:
     template<class... AN>
     auto concat(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(concat_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(concat_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(concat_tag{},                *this, std::forward<AN>(an)...);
@@ -1062,7 +1062,7 @@ public:
     template<class... AN>
     auto concat_map(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(concat_map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(concat_map_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(concat_map_tag{},                *this, std::forward<AN>(an)...);
@@ -1073,7 +1073,7 @@ public:
     template<class... AN>
     auto concat_transform(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(concat_map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(concat_map_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(concat_map_tag{},                *this, std::forward<AN>(an)...);
@@ -1084,7 +1084,7 @@ public:
     template<class... AN>
     auto with_latest_from(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(with_latest_from_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(with_latest_from_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(with_latest_from_tag{},                *this, std::forward<AN>(an)...);
@@ -1096,7 +1096,7 @@ public:
     template<class... AN>
     auto combine_latest(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(combine_latest_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(combine_latest_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(combine_latest_tag{},                *this, std::forward<AN>(an)...);
@@ -1107,7 +1107,7 @@ public:
     template<class... AN>
     auto zip(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(zip_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(zip_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(zip_tag{},                *this, std::forward<AN>(an)...);
@@ -1118,7 +1118,7 @@ public:
     template<class... AN>
     inline auto group_by(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(group_by_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(group_by_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(group_by_tag{},                *this, std::forward<AN>(an)...);
@@ -1129,7 +1129,7 @@ public:
     template<class... AN>
     auto ignore_elements(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(observable_member(ignore_elements_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    -> decltype(observable_member(ignore_elements_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
     /// \endcond
     {
         return  observable_member(ignore_elements_tag{},                *this, std::forward<AN>(an)...);
@@ -1140,7 +1140,7 @@ public:
     template<class... AN>
     auto multicast(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(multicast_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(multicast_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(multicast_tag{},                *this, std::forward<AN>(an)...);
@@ -1151,7 +1151,7 @@ public:
     template<class... AN>
     auto publish(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(publish_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(publish_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(publish_tag{},                *this, std::forward<AN>(an)...);
@@ -1162,7 +1162,7 @@ public:
     template<class... AN>
     auto publish_synchronized(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(publish_synchronized_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(publish_synchronized_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(publish_synchronized_tag{},                *this, std::forward<AN>(an)...);
@@ -1173,7 +1173,7 @@ public:
     template<class... AN>
     auto replay(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(replay_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(replay_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(replay_tag{},                *this, std::forward<AN>(an)...);
@@ -1184,7 +1184,7 @@ public:
     template<class... AN>
     auto subscribe_on(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(subscribe_on_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(subscribe_on_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(subscribe_on_tag{},                *this, std::forward<AN>(an)...);
@@ -1195,7 +1195,7 @@ public:
     template<class... AN>
     auto observe_on(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(observe_on_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(observe_on_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(observe_on_tag{},                *this, std::forward<AN>(an)...);
@@ -1206,7 +1206,7 @@ public:
     template<class... AN>
     auto reduce(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(reduce_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(reduce_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(reduce_tag{},                *this, std::forward<AN>(an)...);
@@ -1217,7 +1217,7 @@ public:
     template<class... AN>
     auto accumulate(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(reduce_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(reduce_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(reduce_tag{},                *this, std::forward<AN>(an)...);
@@ -1228,7 +1228,7 @@ public:
     template<class... AN>
     auto first(AN**...) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(delayed_type<first_tag, AN...>::value(), *(this_type*)nullptr))
+        -> decltype(observable_member(delayed_type<first_tag, AN...>::value(), std::declval<this_type>()))
         /// \endcond
     {
         return      observable_member(delayed_type<first_tag, AN...>::value(),                *this);
@@ -1240,7 +1240,7 @@ public:
     template<class... AN>
     auto last(AN**...) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(delayed_type<last_tag, AN...>::value(), *(this_type*)nullptr))
+        -> decltype(observable_member(delayed_type<last_tag, AN...>::value(), std::declval<this_type>()))
         /// \endcond
     {
         return      observable_member(delayed_type<last_tag, AN...>::value(),                *this);
@@ -1252,7 +1252,7 @@ public:
     template<class... AN>
     auto count(AN**...) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(delayed_type<reduce_tag, AN...>::value(), *(this_type*)nullptr, 0, rxu::count(), identity_for<int>()))
+        -> decltype(observable_member(delayed_type<reduce_tag, AN...>::value(), std::declval<this_type>(), 0, rxu::count(), identity_for<int>()))
         /// \endcond
     {
         return      observable_member(delayed_type<reduce_tag, AN...>::value(),                *this, 0, rxu::count(), identity_for<int>());
@@ -1264,7 +1264,7 @@ public:
     template<class... AN>
     auto sum(AN**...) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(delayed_type<sum_tag, AN...>::value(), *(this_type*)nullptr))
+        -> decltype(observable_member(delayed_type<sum_tag, AN...>::value(), std::declval<this_type>()))
         /// \endcond
     {
         return      observable_member(delayed_type<sum_tag, AN...>::value(),                *this);
@@ -1276,7 +1276,7 @@ public:
     template<class... AN>
     auto average(AN**...) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(delayed_type<average_tag, AN...>::value(), *(this_type*)nullptr))
+        -> decltype(observable_member(delayed_type<average_tag, AN...>::value(), std::declval<this_type>()))
         /// \endcond
     {
         return      observable_member(delayed_type<average_tag, AN...>::value(),                *this);
@@ -1288,7 +1288,7 @@ public:
     template<class... AN>
     auto max(AN**...) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(delayed_type<max_tag, AN...>::value(), *(this_type*)nullptr))
+        -> decltype(observable_member(delayed_type<max_tag, AN...>::value(), std::declval<this_type>()))
         /// \endcond
     {
         return      observable_member(delayed_type<max_tag, AN...>::value(),                *this);
@@ -1300,7 +1300,7 @@ public:
     template<class... AN>
     auto min(AN**...) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(delayed_type<min_tag, AN...>::value(), *(this_type*)nullptr))
+        -> decltype(observable_member(delayed_type<min_tag, AN...>::value(), std::declval<this_type>()))
         /// \endcond
     {
         return      observable_member(delayed_type<min_tag, AN...>::value(),                *this);
@@ -1312,7 +1312,7 @@ public:
     template<class... AN>
     auto scan(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(scan_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(scan_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(scan_tag{},                *this, std::forward<AN>(an)...);
@@ -1323,7 +1323,7 @@ public:
     template<class... AN>
     auto sample_with_time(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(sample_with_time_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(sample_with_time_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(sample_with_time_tag{},                *this, std::forward<AN>(an)...);
@@ -1334,7 +1334,7 @@ public:
     template<class... AN>
     auto skip(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(skip_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(skip_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(skip_tag{},                *this, std::forward<AN>(an)...);
@@ -1345,7 +1345,7 @@ public:
     template<class... AN>
     auto skip_while(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(skip_while_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(skip_while_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(skip_while_tag{},                *this, std::forward<AN>(an)...);
@@ -1356,7 +1356,7 @@ public:
     template<class... AN>
     auto skip_last(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(skip_last_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(skip_last_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(skip_last_tag{},                *this, std::forward<AN>(an)...);
@@ -1367,7 +1367,7 @@ public:
     template<class... AN>
     auto skip_until(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(skip_until_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(skip_until_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(skip_until_tag{},                *this, std::forward<AN>(an)...);
@@ -1378,7 +1378,7 @@ public:
     template<class... AN>
     auto take(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(take_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(take_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(take_tag{},                *this, std::forward<AN>(an)...);
@@ -1389,7 +1389,7 @@ public:
     template<class... AN>
     auto take_last(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(take_last_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(take_last_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(take_last_tag{},                *this, std::forward<AN>(an)...);
@@ -1400,7 +1400,7 @@ public:
     template<class... AN>
     auto take_until(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(take_until_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(take_until_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(take_until_tag{},                *this, std::forward<AN>(an)...);
@@ -1411,7 +1411,7 @@ public:
     template<class... AN>
     auto take_while(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(take_while_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(take_while_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(take_while_tag{},                *this, std::forward<AN>(an)...);
@@ -1422,7 +1422,7 @@ public:
     template<class... AN>
     auto repeat(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(repeat_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(repeat_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(repeat_tag{},                *this, std::forward<AN>(an)...);
@@ -1433,7 +1433,7 @@ public:
     template<class... AN>
     auto retry(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(retry_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(retry_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(retry_tag{},                *(this_type*)this, std::forward<AN>(an)...);
@@ -1444,7 +1444,7 @@ public:
     template<class... AN>
     auto start_with(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(start_with_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(start_with_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(start_with_tag{},                *this, std::forward<AN>(an)...);
@@ -1455,7 +1455,7 @@ public:
     template<class... AN>
     auto pairwise(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(observable_member(pairwise_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        -> decltype(observable_member(pairwise_tag{}, std::declval<this_type>(), std::forward<AN>(an)...))
         /// \endcond
     {
         return      observable_member(pairwise_tag{},                *this, std::forward<AN>(an)...);

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -27,7 +27,7 @@ struct has_on_subscribe_for
     static not_void check(...);
 
     using detail_result = decltype(check<rxu::decay_t < Subscriber>, T > (0));
-    static const bool value = std::is_same<detail_result, void>::value;
+    static const bool value = std::is_same_v<detail_result, void>;
 };
 
 }
@@ -478,7 +478,7 @@ template<class T, class SourceOperator>
 class observable
     : public observable_base<T>
 {
-    static_assert(std::is_same<T, typename SourceOperator::value_type>::value, "SourceOperator::value_type must be the same as T in observable<T, SourceOperator>");
+    static_assert(std::is_same_v<T, typename SourceOperator::value_type>, "SourceOperator::value_type must be the same as T in observable<T, SourceOperator>");
 
     using this_type = observable<T, SourceOperator>;
 
@@ -501,7 +501,7 @@ private:
         using subscriber_type = rxu::decay_t<Subscriber>;
 
         static_assert(is_subscriber<subscriber_type>::value, "subscribe must be passed a subscriber");
-        static_assert(std::is_same<typename source_operator_type::value_type, T>::value && std::is_convertible<T*, typename subscriber_type::value_type*>::value, "the value types in the sequence must match or be convertible");
+        static_assert(std::is_same_v<typename source_operator_type::value_type, T> && std::is_convertible<T*, typename subscriber_type::value_type*>::value, "the value types in the sequence must match or be convertible");
         static_assert(detail::has_on_subscribe_for<subscriber_type, source_operator_type>::value, "inner must have on_subscribe method that accepts this subscriber ");
 
         trace_activity().subscribe_enter(*this, o);

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -26,7 +26,7 @@ struct has_on_subscribe_for
     template<class CS, class CT>
     static not_void check(...);
 
-    typedef decltype(check<rxu::decay_t<Subscriber>, T>(0)) detail_result;
+    using detail_result = decltype(check<rxu::decay_t < Subscriber>, T > (0));
     static const bool value = std::is_same<detail_result, void>::value;
 };
 
@@ -39,7 +39,7 @@ class dynamic_observable
     struct state_type
         : public std::enable_shared_from_this<state_type>
     {
-        typedef std::function<void(subscriber<T>)> onsubscribe_type;
+        using onsubscribe_type = std::function<void(subscriber < T > )>;
 
         onsubscribe_type on_subscribe;
     };
@@ -64,7 +64,7 @@ class dynamic_observable
 
 public:
 
-    typedef tag_dynamic_observable dynamic_observable_tag;
+    using dynamic_observable_tag = tag_dynamic_observable;
 
     dynamic_observable()
     {
@@ -110,10 +110,10 @@ struct resolve_observable;
 template<class Default, class SO>
 struct resolve_observable<true, Default, SO>
 {
-    typedef typename SO::type type;
-    typedef typename type::value_type value_type;
+    using type = typename SO::type;
+    using value_type = typename type::value_type;
     static const bool value = true;
-    typedef observable<value_type, type> observable_type;
+    using observable_type = observable<value_type, type>;
     template<class... AN>
     static observable_type make(const Default&, AN&&... an) {
         return observable_type(type(std::forward<AN>(an)...));
@@ -123,7 +123,7 @@ template<class Default, class SO>
 struct resolve_observable<false, Default, SO>
 {
     static const bool value = false;
-    typedef Default observable_type;
+    using observable_type = Default;
     template<class... AN>
     static observable_type make(const observable_type& that, const AN&...) {
         return that;
@@ -132,10 +132,10 @@ struct resolve_observable<false, Default, SO>
 template<class SO>
 struct resolve_observable<true, void, SO>
 {
-    typedef typename SO::type type;
-    typedef typename type::value_type value_type;
+    using type = typename SO::type;
+    using value_type = typename type::value_type;
     static const bool value = true;
-    typedef observable<value_type, type> observable_type;
+    using observable_type = observable<value_type, type>;
     template<class... AN>
     static observable_type make(AN&&... an) {
         return observable_type(type(std::forward<AN>(an)...));
@@ -145,7 +145,7 @@ template<class SO>
 struct resolve_observable<false, void, SO>
 {
     static const bool value = false;
-    typedef void observable_type;
+    using observable_type = void;
     template<class... AN>
     static observable_type make(const AN&...) {
     }
@@ -212,7 +212,7 @@ class blocking_observable
     }
 
 public:
-    typedef rxu::decay_t<Observable> observable_type;
+    using observable_type = rxu::decay_t<Observable>;
     observable_type source;
     ~blocking_observable()
     {
@@ -480,10 +480,10 @@ class observable
 {
     static_assert(std::is_same<T, typename SourceOperator::value_type>::value, "SourceOperator::value_type must be the same as T in observable<T, SourceOperator>");
 
-    typedef observable<T, SourceOperator> this_type;
+    using this_type = observable<T, SourceOperator>;
 
 public:
-    typedef rxu::decay_t<SourceOperator> source_operator_type;
+    using source_operator_type = rxu::decay_t<SourceOperator>;
     mutable source_operator_type source_operator;
 
 private:
@@ -498,7 +498,7 @@ private:
     auto detail_subscribe(Subscriber o) const
         -> composite_subscription {
 
-        typedef rxu::decay_t<Subscriber> subscriber_type;
+        using subscriber_type = rxu::decay_t<Subscriber>;
 
         static_assert(is_subscriber<subscriber_type>::value, "subscribe must be passed a subscriber");
         static_assert(std::is_same<typename source_operator_type::value_type, T>::value && std::is_convertible<T*, typename subscriber_type::value_type*>::value, "the value types in the sequence must match or be convertible");
@@ -527,7 +527,7 @@ private:
     }
 
 public:
-    typedef T value_type;
+    using value_type = T;
 
     static_assert(rxo::is_operator<source_operator_type>::value || rxs::is_source<source_operator_type>::value, "observable must wrap an operator or source");
 

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -116,7 +116,7 @@ struct is_on_next_of
 {
     struct not_void {};
     template<class CT, class CF>
-    static auto check(int) -> decltype((*(CF*)nullptr)(*(CT*)nullptr));
+    static auto check(int) -> decltype(std::declval<CF>()(std::declval<CT>()));
     template<class CT, class CF>
     static not_void check(...);
 
@@ -129,11 +129,11 @@ struct is_on_error
 {
     struct not_void {};
     template<class CF>
-    static auto check(int) -> decltype((*(CF*)nullptr)(*(rxu::error_ptr*)nullptr));
+    static auto check(int) -> decltype(std::declval<CF>()(std::declval<rxu::error_ptr>()));
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same<decltype(check<rxu::decay_t<F>>(0)), void>::value;
+    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 template<class State, class F>
@@ -141,7 +141,7 @@ struct is_on_error_for
 {
     struct not_void {};
     template<class CF>
-    static auto check(int) -> decltype((*(CF*)nullptr)(*(State*)nullptr, *(rxu::error_ptr*)nullptr));
+    static auto check(int) -> decltype(std::declval<CF>()(std::declval<State>(), std::declval<rxu::error_ptr>()));
     template<class CF>
     static not_void check(...);
 
@@ -153,7 +153,7 @@ struct is_on_completed
 {
     struct not_void {};
     template<class CF>
-    static auto check(int) -> decltype((*(CF*)nullptr)());
+    static auto check(int) -> decltype(std::declval<CF>()());
     template<class CF>
     static not_void check(...);
 
@@ -627,7 +627,7 @@ namespace detail {
 template<class F>
 struct maybe_from_result
 {
-    typedef decltype((*(F*)nullptr)()) decl_result_type;
+    using decl_result_type = decltype(std::declval<F>()());
     typedef rxu::decay_t<decl_result_type> result_type;
     typedef rxu::maybe<result_type> type;
 };

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -121,7 +121,7 @@ struct is_on_next_of
     static not_void check(...);
 
     using detail_result = decltype(check<T, rxu::decay_t < F>>(0));
-    static const bool value = std::is_same<detail_result, void>::value;
+    static const bool value = std::is_same_v<detail_result, void>;
 };
 
 template<class F>
@@ -145,7 +145,7 @@ struct is_on_error_for
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same<decltype(check<rxu::decay_t<F>>(0)), void>::value;
+    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 template<class F>
@@ -157,7 +157,7 @@ struct is_on_completed
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same<decltype(check<rxu::decay_t<F>>(0)), void>::value;
+    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 }
@@ -182,15 +182,15 @@ public:
     using this_type = observer<T, State, OnNext, OnError, OnCompleted>;
     using state_t = rxu::decay_t<State>;
     using on_next_t = typename std::conditional<
-        !std::is_same<void, OnNext>::value,
+        !std::is_same_v<void, OnNext>,
         rxu::decay_t<OnNext>,
         detail::OnNextForward<T, State, OnNext>>::type;
     using on_error_t = typename std::conditional<
-        !std::is_same<void, OnError>::value,
+        !std::is_same_v<void, OnError>,
         rxu::decay_t<OnError>,
         detail::OnErrorForward<State, OnError>>::type;
     using on_completed_t = typename std::conditional<
-        !std::is_same<void, OnCompleted>::value,
+        !std::is_same_v<void, OnCompleted>,
         rxu::decay_t<OnCompleted>,
         detail::OnCompletedForward<State, OnCompleted>>::type;
 
@@ -271,15 +271,15 @@ class observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted> 
 public:
     using this_type = observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>;
     using on_next_t = typename std::conditional<
-        !std::is_same<void, OnNext>::value,
+        !std::is_same_v<void, OnNext>,
         rxu::decay_t<OnNext>,
         detail::OnNextEmpty<T>>::type;
     using on_error_t = typename std::conditional<
-        !std::is_same<void, OnError>::value,
+        !std::is_same_v<void, OnError>,
         rxu::decay_t<OnError>,
         detail::OnErrorEmpty>::type;
     using on_completed_t = typename std::conditional<
-        !std::is_same<void, OnCompleted>::value,
+        !std::is_same_v<void, OnCompleted>,
         rxu::decay_t<OnCompleted>,
         detail::OnCompletedEmpty>::type;
 

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -181,18 +181,9 @@ class observer : public observer_base<T>
 public:
     using this_type = observer<T, State, OnNext, OnError, OnCompleted>;
     using state_t = rxu::decay_t<State>;
-    using on_next_t = typename std::conditional<
-        !std::is_same_v<void, OnNext>,
-        rxu::decay_t<OnNext>,
-        detail::OnNextForward<T, State, OnNext>>::type;
-    using on_error_t = typename std::conditional<
-        !std::is_same_v<void, OnError>,
-        rxu::decay_t<OnError>,
-        detail::OnErrorForward<State, OnError>>::type;
-    using on_completed_t = typename std::conditional<
-        !std::is_same_v<void, OnCompleted>,
-        rxu::decay_t<OnCompleted>,
-        detail::OnCompletedForward<State, OnCompleted>>::type;
+    using on_next_t = typename std::conditional_t<!std::is_same_v<void, OnNext>, rxu::decay_t<OnNext>, detail::OnNextForward<T, State, OnNext>>;
+    using on_error_t = typename std::conditional_t<!std::is_same_v<void, OnError>, rxu::decay_t<OnError>, detail::OnErrorForward<State, OnError>>;
+    using on_completed_t = typename std::conditional_t<!std::is_same_v<void, OnCompleted>, rxu::decay_t<OnCompleted>, detail::OnCompletedForward<State, OnCompleted>>;
 
 private:
     mutable state_t state;
@@ -270,18 +261,9 @@ class observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted> 
 {
 public:
     using this_type = observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>;
-    using on_next_t = typename std::conditional<
-        !std::is_same_v<void, OnNext>,
-        rxu::decay_t<OnNext>,
-        detail::OnNextEmpty<T>>::type;
-    using on_error_t = typename std::conditional<
-        !std::is_same_v<void, OnError>,
-        rxu::decay_t<OnError>,
-        detail::OnErrorEmpty>::type;
-    using on_completed_t = typename std::conditional<
-        !std::is_same_v<void, OnCompleted>,
-        rxu::decay_t<OnCompleted>,
-        detail::OnCompletedEmpty>::type;
+    using on_next_t = typename std::conditional_t<!std::is_same_v<void, OnNext>, rxu::decay_t<OnNext>, detail::OnNextEmpty<T>>;
+    using on_error_t = typename std::conditional_t<!std::is_same_v<void, OnError>, rxu::decay_t<OnError>, detail::OnErrorEmpty>;
+    using on_completed_t = typename std::conditional_t<!std::is_same_v<void, OnCompleted>, rxu::decay_t<OnCompleted>, detail::OnCompletedEmpty>;
 
 private:
     on_next_t onnext;

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -13,8 +13,8 @@ namespace rxcpp {
 template<class T>
 struct observer_base
 {
-    typedef T value_type;
-    typedef tag_observer observer_tag;
+    using value_type = T;
+    using observer_tag = tag_observer;
 };
 
 namespace detail {
@@ -120,7 +120,7 @@ struct is_on_next_of
     template<class CT, class CF>
     static not_void check(...);
 
-    typedef decltype(check<T, rxu::decay_t<F>>(0)) detail_result;
+    using detail_result = decltype(check<T, rxu::decay_t < F>>(0));
     static const bool value = std::is_same<detail_result, void>::value;
 };
 
@@ -391,7 +391,7 @@ template<class T>
 class observer<T, void, void, void, void> : public observer_base<T>
 {
 public:
-    typedef tag_dynamic_observer dynamic_observer_tag;
+    using dynamic_observer_tag = tag_dynamic_observer;
 
 private:
     using this_type = observer<T, void, void, void, void>;
@@ -628,8 +628,8 @@ template<class F>
 struct maybe_from_result
 {
     using decl_result_type = decltype(std::declval<F>()());
-    typedef rxu::decay_t<decl_result_type> result_type;
-    typedef rxu::maybe<result_type> type;
+    using result_type = rxu::decay_t<decl_result_type>;
+    using type = rxu::maybe<result_type>;
 };
 
 }

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -88,7 +88,7 @@ public:
 
     template<class Observable>
     auto operator()(Observable source) const 
-        -> decltype(rxu::apply(std::tuple_cat(std::make_tuple(tag_type{}, source), (*(tuple_type*)nullptr)), (*(this_type*)nullptr))) {
+        -> decltype(rxu::apply(std::tuple_cat(std::make_tuple(tag_type{}, source), std::declval<tuple_type>()), std::declval<this_type>())) {
         return      rxu::apply(std::tuple_cat(std::make_tuple(tag_type{}, source),                      an),                  *this);
     }
 };

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -15,8 +15,8 @@ struct tag_operator {};
 template<class T>
 struct operator_base
 {
-    typedef T value_type;
-    typedef tag_operator operator_tag;
+    using value_type = T;
+    using operator_tag = tag_operator;
 };
 
 namespace detail {

--- a/Rx/v2/src/rxcpp/rx-predef.hpp
+++ b/Rx/v2/src/rxcpp/rx-predef.hpp
@@ -143,8 +143,8 @@ struct defer_observable;
 struct tag_observable {};
 template<class T>
 struct observable_base {
-    typedef tag_observable observable_tag;
-    typedef T value_type;
+    using observable_tag = tag_observable;
+    using value_type = T;
 };
 
 namespace detail {
@@ -298,9 +298,9 @@ struct identity_for
 template<class T, class Seed, class Accumulator>
 struct is_accumulate_function_for {
 
-    typedef rxu::decay_t<Accumulator> accumulator_type;
-    typedef rxu::decay_t<Seed> seed_type;
-    typedef T source_value_type;
+    using accumulator_type = rxu::decay_t<Accumulator>;
+    using seed_type = rxu::decay_t<Seed>;
+    using source_value_type = T;
 
     struct tag_not_valid {};
     template<class CS, class CV, class CRS>
@@ -308,7 +308,7 @@ struct is_accumulate_function_for {
     template<class CS, class CV, class CRS>
     static tag_not_valid check(...);
 
-    typedef decltype(check<seed_type, source_value_type, accumulator_type>(0)) type;
+    using type = decltype(check<seed_type, source_value_type, accumulator_type>(0));
     static const bool value = std::is_same<type, seed_type>::value;
 };
 

--- a/Rx/v2/src/rxcpp/rx-predef.hpp
+++ b/Rx/v2/src/rxcpp/rx-predef.hpp
@@ -202,8 +202,7 @@ template<class T>
 class dynamic_connectable_observable;
 
 template<class T,
-    class SourceObservable = typename std::conditional<std::is_same_v<T, void>,
-        void, dynamic_connectable_observable<T>>::type>
+    class SourceObservable = typename std::conditional_t<std::is_same_v<T, void>, void, dynamic_connectable_observable<T>>>
 class connectable_observable;
 
 struct tag_connectable_observable : public tag_observable {};
@@ -236,8 +235,7 @@ template<class K, class T>
 class dynamic_grouped_observable;
 
 template<class K, class T,
-    class SourceObservable = typename std::conditional<std::is_same_v<T, void>,
-        void, dynamic_grouped_observable<K, T>>::type>
+    class SourceObservable = typename std::conditional_t<std::is_same_v<T, void>, void, dynamic_grouped_observable<K, T>>>
 class grouped_observable;
 
 template<class K, class T, class Source>

--- a/Rx/v2/src/rxcpp/rx-predef.hpp
+++ b/Rx/v2/src/rxcpp/rx-predef.hpp
@@ -202,7 +202,7 @@ template<class T>
 class dynamic_connectable_observable;
 
 template<class T,
-    class SourceObservable = typename std::conditional<std::is_same<T, void>::value,
+    class SourceObservable = typename std::conditional<std::is_same_v<T, void>,
         void, dynamic_connectable_observable<T>>::type>
 class connectable_observable;
 
@@ -236,7 +236,7 @@ template<class K, class T>
 class dynamic_grouped_observable;
 
 template<class K, class T,
-    class SourceObservable = typename std::conditional<std::is_same<T, void>::value,
+    class SourceObservable = typename std::conditional<std::is_same_v<T, void>,
         void, dynamic_grouped_observable<K, T>>::type>
 class grouped_observable;
 
@@ -270,7 +270,7 @@ struct is_operator_factory_for {
 
     using type = decltype(check<function_type, source_type>(0));
 
-    static const bool value = !std::is_same<type, tag_not_valid>::value && is_observable<source_type>::value;
+    static const bool value = !std::is_same_v<type, tag_not_valid> && is_observable<source_type>::value;
 };
 
 //
@@ -309,7 +309,7 @@ struct is_accumulate_function_for {
     static tag_not_valid check(...);
 
     using type = decltype(check<seed_type, source_value_type, accumulator_type>(0));
-    static const bool value = std::is_same<type, seed_type>::value;
+    static const bool value = std::is_same_v<type, seed_type>;
 };
 
 }

--- a/Rx/v2/src/rxcpp/rx-predef.hpp
+++ b/Rx/v2/src/rxcpp/rx-predef.hpp
@@ -264,7 +264,7 @@ struct is_operator_factory_for {
 
     struct tag_not_valid;
     template<class CS, class CO>
-    static auto check(int) -> decltype((*(CS*)nullptr)((*(CO*)nullptr)));
+    static auto check(int) -> decltype(std::declval<CS>()(std::declval<CO>()));
     template<class CS, class CO>
     static tag_not_valid check(...);
 
@@ -304,7 +304,7 @@ struct is_accumulate_function_for {
 
     struct tag_not_valid {};
     template<class CS, class CV, class CRS>
-    static auto check(int) -> decltype((*(CRS*)nullptr)(*(CS*)nullptr, *(CV*)nullptr));
+    static auto check(int) -> decltype(std::declval<CRS>()(std::declval<CS>(), std::declval<CV>()));
     template<class CS, class CV, class CRS>
     static tag_not_valid check(...);
 

--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -121,7 +121,7 @@ public:
 
 struct action_base
 {
-    typedef tag_action action_tag;
+    using action_tag = tag_action;
 };
 
 class schedulable;
@@ -183,7 +183,7 @@ struct is_action_function
 {
     struct not_void {};
     template<class CF>
-    static auto check(int) -> decltype((*(CF*)nullptr)(*(schedulable*)nullptr));
+    static auto check(int) -> decltype(std::declval<CF>()(std::declval<schedulable>()));
     template<class CF>
     static not_void check(...);
 
@@ -654,7 +654,7 @@ namespace detail {
 class action_type
     : public std::enable_shared_from_this<action_type>
 {
-    typedef action_type this_type;
+    using this_type = action_type;
 
 public:
     typedef std::function<void(const schedulable&, const recurse&)> function_type;

--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -187,7 +187,7 @@ struct is_action_function
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same<decltype(check<rxu::decay_t<F>>(0)), void>::value;
+    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 }

--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -17,16 +17,16 @@ class scheduler_interface;
 namespace detail {
 
 class action_type;
-typedef std::shared_ptr<action_type> action_ptr;
+    using action_ptr = std::shared_ptr<action_type>;
 
-typedef std::shared_ptr<worker_interface> worker_interface_ptr;
-typedef std::shared_ptr<const worker_interface> const_worker_interface_ptr;
+    using worker_interface_ptr = std::shared_ptr<worker_interface>;
+    using const_worker_interface_ptr = std::shared_ptr<const worker_interface>;
 
-typedef std::weak_ptr<worker_interface> worker_interface_weak_ptr;
-typedef std::weak_ptr<const worker_interface> const_worker_interface_weak_ptr;
+    using worker_interface_weak_ptr = std::weak_ptr<worker_interface>;
+    using const_worker_interface_weak_ptr = std::weak_ptr<const worker_interface>;
 
-typedef std::shared_ptr<scheduler_interface> scheduler_interface_ptr;
-typedef std::shared_ptr<const scheduler_interface> const_scheduler_interface_ptr;
+    using scheduler_interface_ptr = std::shared_ptr<scheduler_interface>;
+    using const_scheduler_interface_ptr = std::shared_ptr<const scheduler_interface>;
 
 inline action_ptr shared_empty() {
     static action_ptr shared_empty = std::make_shared<detail::action_type>();
@@ -129,7 +129,7 @@ class schedulable;
 /// action provides type-forgetting for a potentially recursive set of calls to a function that takes a schedulable
 class action : public action_base
 {
-    typedef action this_type;
+    using this_type = action;
     detail::action_ptr inner;
 public:
     action()
@@ -151,22 +151,22 @@ public:
 
 struct scheduler_base
 {
-    typedef std::chrono::steady_clock clock_type;
-    typedef tag_scheduler scheduler_tag;
+    using clock_type = std::chrono::steady_clock;
+    using scheduler_tag = tag_scheduler;
 };
 
 struct worker_base : public subscription_base
 {
-    typedef tag_worker worker_tag;
+    using worker_tag = tag_worker;
 };
 
 class worker_interface
     : public std::enable_shared_from_this<worker_interface>
 {
-    typedef worker_interface this_type;
+    using this_type = worker_interface;
 
 public:
-    typedef scheduler_base::clock_type clock_type;
+    using clock_type = scheduler_base::clock_type;
 
     virtual ~worker_interface() {}
 
@@ -199,14 +199,14 @@ class weak_worker;
 /// some inner implementations will impose additional constraints on the execution of items.
 class worker : public worker_base
 {
-    typedef worker this_type;
+    using this_type = worker;
     detail::worker_interface_ptr inner;
     composite_subscription lifetime;
     friend bool operator==(const worker&, const worker&);
     friend class weak_worker;
 public:
-    typedef scheduler_base::clock_type clock_type;
-    typedef composite_subscription::weak_subscription weak_subscription;
+    using clock_type = scheduler_base::clock_type;
+    using weak_subscription = composite_subscription::weak_subscription;
 
     worker()
     {
@@ -353,10 +353,10 @@ public:
 class scheduler_interface
     : public std::enable_shared_from_this<scheduler_interface>
 {
-    typedef scheduler_interface this_type;
+    using this_type = scheduler_interface;
 
 public:
-    typedef scheduler_base::clock_type clock_type;
+    using clock_type = scheduler_base::clock_type;
 
     virtual ~scheduler_interface() {}
 
@@ -371,7 +371,7 @@ struct schedulable_base :
     public worker_base,
     public action_base
 {
-    typedef tag_schedulable schedulable_tag;
+    using schedulable_tag = tag_schedulable;
 };
 
 /*!
@@ -382,11 +382,11 @@ struct schedulable_base :
 */
 class scheduler : public scheduler_base
 {
-    typedef scheduler this_type;
+    using this_type = scheduler;
     detail::scheduler_interface_ptr inner;
     friend bool operator==(const scheduler&, const scheduler&);
 public:
-    typedef scheduler_base::clock_type clock_type;
+    using clock_type = scheduler_base::clock_type;
 
     scheduler()
     {
@@ -425,7 +425,7 @@ inline scheduler make_scheduler(std::shared_ptr<scheduler_interface> si) {
 
 class schedulable : public schedulable_base
 {
-    typedef schedulable this_type;
+    using this_type = schedulable;
 
     composite_subscription lifetime;
     weak_worker controller;
@@ -501,8 +501,8 @@ class schedulable : public schedulable_base
     recursed_scope_type recursed_scope;
 
 public:
-    typedef composite_subscription::weak_subscription weak_subscription;
-    typedef scheduler_base::clock_type clock_type;
+    using weak_subscription = composite_subscription::weak_subscription;
+    using clock_type = scheduler_base::clock_type;
 
     ~schedulable()
     {
@@ -657,7 +657,7 @@ class action_type
     using this_type = action_type;
 
 public:
-    typedef std::function<void(const schedulable&, const recurse&)> function_type;
+    using function_type = std::function<void(const schedulable &, const recurse &)>;
 
 private:
     function_type f;
@@ -683,10 +683,10 @@ public:
 class action_tailrecurser
     : public std::enable_shared_from_this<action_type>
 {
-    typedef action_type this_type;
+    using this_type = action_type;
 
 public:
-    typedef std::function<void(const schedulable&)> function_type;
+    using function_type = std::function<void(const schedulable &)>;
 
 private:
     function_type f;
@@ -870,7 +870,7 @@ namespace detail {
 template<class TimePoint>
 struct time_schedulable
 {
-    typedef TimePoint time_point_type;
+    using time_point_type = TimePoint;
 
     time_schedulable(TimePoint when, schedulable a)
         : when(when)
@@ -888,10 +888,10 @@ struct time_schedulable
 template<class TimePoint>
 class schedulable_queue {
 public:
-    typedef time_schedulable<TimePoint> item_type;
-    typedef std::pair<item_type, int64_t> elem_type;
-    typedef std::vector<elem_type> container_type;
-    typedef const item_type& const_reference;
+    using item_type = time_schedulable<TimePoint>;
+    using elem_type = std::pair<item_type, int64_t>;
+    using container_type = std::vector<elem_type>;
+    using const_reference = const item_type &;
 
 private:
     struct compare_elem
@@ -906,11 +906,7 @@ private:
         }
     };
 
-    typedef std::priority_queue<
-        elem_type,
-        container_type,
-        compare_elem
-    > queue_type;
+    using queue_type = std::priority_queue<elem_type, container_type, compare_elem>;
 
     queue_type q;
 

--- a/Rx/v2/src/rxcpp/rx-sources.hpp
+++ b/Rx/v2/src/rxcpp/rx-sources.hpp
@@ -16,8 +16,8 @@ struct tag_source {};
 template<class T>
 struct source_base
 {
-    typedef T value_type;
-    typedef tag_source source_tag;
+    using value_type = T;
+    using source_tag = tag_source;
 };
 template<class T>
 class is_source

--- a/Rx/v2/src/rxcpp/rx-subscriber.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscriber.hpp
@@ -124,8 +124,8 @@ public:
     subscriber(
         const subscriber<T, O>& o,
         typename std::enable_if<
-               !std::is_same<O, observer<T>>::value &&
-               std::is_same<Observer, observer<T>>::value, void**>::type = nullptr)
+               !std::is_same_v<O, observer<T>> &&
+               std::is_same_v<Observer, observer<T>>, void**>::type = nullptr)
         : lifetime(o.lifetime)
         , destination(o.destination.as_dynamic())
         , id(o.id)

--- a/Rx/v2/src/rxcpp/rx-subscriber.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscriber.hpp
@@ -12,7 +12,7 @@ namespace rxcpp {
 template<class T>
 struct subscriber_base : public observer_base<T>, public subscription_base
 {
-    typedef tag_subscriber subscriber_tag;
+    using subscriber_tag = tag_subscriber;
 };
 
 /*!
@@ -26,8 +26,8 @@ class subscriber : public subscriber_base<T>
 {
     static_assert(!is_subscriber<Observer>::value, "not allowed to nest subscribers");
     static_assert(is_observer<Observer>::value, "subscriber must contain an observer<T, ...>");
-    typedef subscriber<T, Observer> this_type;
-    typedef rxu::decay_t<Observer> observer_type;
+    using this_type = subscriber<T, Observer>;
+    using observer_type = rxu::decay_t<Observer>;
 
     composite_subscription lifetime;
     observer_type destination;
@@ -102,7 +102,7 @@ class subscriber : public subscriber_base<T>
 
     subscriber();
 public:
-    typedef typename composite_subscription::weak_subscription weak_subscription;
+    using weak_subscription = typename composite_subscription::weak_subscription;
 
     subscriber(const this_type& o)
         : lifetime(o.lifetime)

--- a/Rx/v2/src/rxcpp/rx-subscription.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscription.hpp
@@ -26,7 +26,7 @@ struct is_unsubscribe_function
 }
 
 struct tag_subscription {};
-struct subscription_base {typedef tag_subscription subscription_tag;};
+struct subscription_base { using subscription_tag = tag_subscription; };
 template<class T>
 class is_subscription
 {
@@ -41,7 +41,7 @@ public:
 template<class Unsubscribe>
 class static_subscription
 {
-    typedef rxu::decay_t<Unsubscribe> unsubscribe_call_type;
+    using unsubscribe_call_type = rxu::decay_t<Unsubscribe>;
     unsubscribe_call_type unsubscribe_call;
     static_subscription()
     {
@@ -81,13 +81,13 @@ class subscription : public subscription_base
         std::atomic<bool> issubscribed;
     };
 public:
-    typedef std::weak_ptr<base_subscription_state> weak_state_type;
+    using weak_state_type = std::weak_ptr<base_subscription_state>;
 
 private:
     template<class I>
     struct subscription_state : public base_subscription_state
     {
-        typedef rxu::decay_t<I> inner_t;
+        using inner_t = rxu::decay_t<I>;
         subscription_state(inner_t i)
             : base_subscription_state(true)
             , inner(std::move(i))
@@ -242,7 +242,7 @@ struct tag_composite_subscription_empty {};
 class composite_subscription_inner
 {
 private:
-    typedef subscription::weak_state_type weak_subscription;
+    using weak_subscription = subscription::weak_state_type;
     struct composite_subscription_state : public std::enable_shared_from_this<composite_subscription_state>
     {
         // invariant: cannot access this data without the lock held.
@@ -381,7 +381,7 @@ private:
     };
 
 public:
-    typedef std::shared_ptr<composite_subscription_state> shared_state_type;
+    using shared_state_type = std::shared_ptr<composite_subscription_state>;
 
 protected:
     mutable shared_state_type state;
@@ -460,9 +460,9 @@ class composite_subscription
     : protected detail::composite_subscription_inner
     , public subscription
 {
-    typedef detail::composite_subscription_inner inner_type;
+    using inner_type = detail::composite_subscription_inner;
 public:
-    typedef subscription::weak_state_type weak_subscription;
+    using weak_subscription = subscription::weak_state_type;
 
     composite_subscription(detail::tag_composite_subscription_empty et)
         : inner_type(et)
@@ -555,7 +555,7 @@ template<class T>
 class resource : public subscription_base
 {
 public:
-    typedef typename composite_subscription::weak_subscription weak_subscription;
+    using weak_subscription = typename composite_subscription::weak_subscription;
 
     resource()
         : lifetime(composite_subscription())

--- a/Rx/v2/src/rxcpp/rx-subscription.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscription.hpp
@@ -16,7 +16,7 @@ struct is_unsubscribe_function
 {
     struct not_void {};
     template<class CF>
-    static auto check(int) -> decltype((*(CF*)nullptr)());
+    static auto check(int) -> decltype(std::declval<CF>()());
     template<class CF>
     static not_void check(...);
 

--- a/Rx/v2/src/rxcpp/rx-subscription.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscription.hpp
@@ -20,7 +20,7 @@ struct is_unsubscribe_function
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same<decltype(check<rxu::decay_t<F>>(0)), void>::value;
+    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 }
@@ -143,7 +143,7 @@ public:
         }
     }
     template<class U>
-    explicit subscription(U u, typename std::enable_if<!std::is_same<subscription, U>::value && is_subscription<U>::value, void**>::type = nullptr)
+    explicit subscription(U u, typename std::enable_if<!std::is_same_v<subscription, U> && is_subscription<U>::value, void**>::type = nullptr)
         // intentionally slice
         : state(std::move((*static_cast<subscription*>(&u)).state))
     {

--- a/Rx/v2/src/rxcpp/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/rx-test.hpp
@@ -38,7 +38,7 @@ struct test_source
         ts->on_subscribe(std::move(o));
     }
     template<class Subscriber>
-    typename std::enable_if<!std::is_same<Subscriber, subscriber<T>>::value, void>::type
+    typename std::enable_if<!std::is_same_v<Subscriber, subscriber<T>>, void>::type
     on_subscribe(Subscriber o) const {
 
         static_assert(is_subscriber<Subscriber>::value, "on_subscribe must be passed a subscriber.");

--- a/Rx/v2/src/rxcpp/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/rx-test.hpp
@@ -15,8 +15,8 @@ template<class T>
 struct test_subject_base
     : public std::enable_shared_from_this<test_subject_base<T>>
 {
-    typedef rxn::recorded<typename rxn::notification<T>::type> recorded_type;
-    typedef std::shared_ptr<test_subject_base<T>> type;
+    using recorded_type = rxn::recorded<typename rxn::notification<T>::type>;
+    using type = std::shared_ptr<test_subject_base<T>>;
 
     virtual ~test_subject_base() {}
     virtual void on_subscribe(subscriber<T>) const =0;
@@ -53,12 +53,12 @@ template<class T>
 class testable_observer
     : public observer<T>
 {
-    typedef observer<T> observer_base;
-    typedef typename detail::test_subject_base<T>::type test_subject;
+    using observer_base = observer<T>;
+    using test_subject = typename detail::test_subject_base<T>::type;
     test_subject ts;
 
 public:
-    typedef typename detail::test_subject_base<T>::recorded_type recorded_type;
+    using recorded_type = typename detail::test_subject_base<T>::recorded_type;
 
     testable_observer(test_subject ts, observer_base ob)
         : observer_base(std::move(ob))
@@ -83,14 +83,14 @@ template<class T>
 class testable_observable
     : public observable<T, typename detail::test_source<T>>
 {
-    typedef observable<T, typename detail::test_source<T>> observable_base;
-    typedef typename detail::test_subject_base<T>::type test_subject;
+    using observable_base = observable<T, typename detail::test_source<T>>;
+    using test_subject = typename detail::test_subject_base<T>::type;
     test_subject ts;
 
     //typedef tag_test_observable observable_tag;
 
 public:
-    typedef typename detail::test_subject_base<T>::recorded_type recorded_type;
+    using recorded_type = typename detail::test_subject_base<T>::recorded_type;
 
     explicit testable_observable(test_subject ts)
         : observable_base(detail::test_source<T>(ts))

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -834,7 +834,7 @@ struct is_duration : detail::is_duration<Decayed> {};
 // C++17 negation
 namespace detail {
     template<class T>
-    struct not_value : std::conditional<T::value, std::false_type, std::true_type>::type {
+    struct not_value : std::conditional_t<T::value, std::false_type, std::true_type> {
     };
 }
 

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -93,13 +93,13 @@ struct values_from;
 template<class T, T Step, T Cursor, T... ValueN>
 struct values_from<T, 0, Step, Cursor, ValueN...>
 {
-    typedef values<T, ValueN...> type;
+    using type = values<T, ValueN...>;
 };
 
 template<class T, std::size_t Remaining, T Step, T Cursor, T... ValueN>
 struct values_from
 {
-    typedef typename values_from<T, Remaining - 1, Step, Cursor + Step, ValueN..., Cursor>::type type;
+    using type = typename values_from<T, Remaining - 1, Step, Cursor + Step, ValueN..., Cursor>::type;
 };
 
 template<bool... BN>
@@ -177,11 +177,11 @@ struct types {};
 struct types_checked {};
 
 namespace detail {
-template<class... TN> struct types_checked_from {typedef types_checked type;};
+template<class... TN> struct types_checked_from { using type = types_checked; };
 }
 
 template<class... TN>
-struct types_checked_from {typedef typename detail::types_checked_from<TN...>::type type;};
+struct types_checked_from { using type = typename detail::types_checked_from<TN...>::type; };
 
 template<class... TN>
 using types_checked_t = typename types_checked_from<TN...>::type;
@@ -199,11 +199,11 @@ using value_types_t = typename expand_value_types<types<TN...>>::type;
 
 
 template<class T, class C = types_checked>
-struct value_type_from : public std::false_type {typedef types_checked type;};
+struct value_type_from : public std::false_type { using type = types_checked; };
 
 template<class T>
 struct value_type_from<T, typename types_checked_from<value_type_t<T>>::type>
-    : public std::true_type {typedef value_type_t<T> type;};
+    : public std::true_type { using type = value_type_t<T>; };
 
 namespace detail {
 template<class F, class Tuple, int... IndexN>
@@ -333,13 +333,13 @@ struct defer_trait
     template<bool R>
     struct tag_valid {static const bool valid = true; static const bool value = R;};
     struct tag_not_valid {static const bool valid = false; static const bool value = false;};
-    typedef Deferred<typename resolve_type<AN>::type...> resolved_type;
+    using resolved_type = Deferred<typename resolve_type<AN>::type...>;
     template<class... CN>
     static auto check(int) -> tag_valid<resolved_type::value>;
     template<class... CN>
     static tag_not_valid check(...);
 
-    typedef decltype(check<AN...>(0)) tag_type;
+    using tag_type = decltype(check<AN...>(0));
     static const bool valid = tag_type::valid;
     static const bool value = tag_type::value;
     static const bool not_value = valid && !value;
@@ -349,16 +349,16 @@ template <template<class... TN> class Deferred, class... AN>
 struct defer_type
 {
     template<class R>
-    struct tag_valid {typedef R type; static const bool value = true;};
-    struct tag_not_valid {typedef void type; static const bool value = false;};
-    typedef Deferred<typename resolve_type<AN>::type...> resolved_type;
+    struct tag_valid { using type = R; static const bool value = true;};
+    struct tag_not_valid { using type = void; static const bool value = false;};
+    using resolved_type = Deferred<typename resolve_type<AN>::type...>;
     template<class... CN>
     static auto check(int) -> tag_valid<resolved_type>;
     template<class... CN>
     static tag_not_valid check(...);
 
-    typedef decltype(check<AN...>(0)) tag_type;
-    typedef typename tag_type::type type;
+    using tag_type = decltype(check<AN...>(0));
+    using type = typename tag_type::type;
     static const bool value = tag_type::value;
 };
 
@@ -366,16 +366,16 @@ template <template<class... TN> class Deferred, class... AN>
 struct defer_value_type
 {
     template<class R>
-    struct tag_valid {typedef R type; static const bool value = true;};
-    struct tag_not_valid {typedef void type; static const bool value = false;};
-    typedef Deferred<typename resolve_type<AN>::type...> resolved_type;
+    struct tag_valid { using type = R; static const bool value = true;};
+    struct tag_not_valid { using type = void; static const bool value = false;};
+    using resolved_type = Deferred<typename resolve_type<AN>::type...>;
     template<class... CN>
     static auto check(int) -> tag_valid<value_type_t<resolved_type>>;
     template<class... CN>
     static tag_not_valid check(...);
 
-    typedef decltype(check<AN...>(0)) tag_type;
-    typedef typename tag_type::type type;
+    using tag_type = decltype(check<AN...>(0));
+    using type = typename tag_type::type;
     static const bool value = tag_type::value;
 };
 
@@ -383,38 +383,38 @@ template <template<class... TN> class Deferred, class... AN>
 struct defer_seed_type
 {
     template<class R>
-    struct tag_valid {typedef R type; static const bool value = true;};
-    struct tag_not_valid {typedef void type; static const bool value = false;};
-    typedef Deferred<typename resolve_type<AN>::type...> resolved_type;
+    struct tag_valid { using type = R; static const bool value = true;};
+    struct tag_not_valid { using type = void; static const bool value = false;};
+    using resolved_type = Deferred<typename resolve_type<AN>::type...>;
     template<class... CN>
     static auto check(int) -> tag_valid<typename resolved_type::seed_type>;
     template<class... CN>
     static tag_not_valid check(...);
 
-    typedef decltype(check<AN...>(0)) tag_type;
-    typedef typename tag_type::type type;
+    using tag_type = decltype(check<AN...>(0));
+    using type = typename tag_type::type;
     static const bool value = tag_type::value;
 };
 
 template <class D>
 struct resolve_type
 {
-    typedef D type;
+    using type = D;
 };
 template <template<class... TN> class Deferred, class... AN>
 struct resolve_type<defer_type<Deferred, AN...>>
 {
-    typedef typename defer_type<Deferred, AN...>::type type;
+    using type = typename defer_type<Deferred, AN...>::type;
 };
 template <template<class... TN> class Deferred, class... AN>
 struct resolve_type<defer_value_type<Deferred, AN...>>
 {
-    typedef typename defer_value_type<Deferred, AN...>::type type;
+    using type = typename defer_value_type<Deferred, AN...>::type;
 };
 template <template<class... TN> class Deferred, class... AN>
 struct resolve_type<defer_seed_type<Deferred, AN...>>
 {
-    typedef typename defer_seed_type<Deferred, AN...>::type type;
+    using type = typename defer_seed_type<Deferred, AN...>::type;
 };
 
 struct plus
@@ -617,9 +617,9 @@ public:
         reset();
     }
 
-    typedef T value_type;
-    typedef T* iterator;
-    typedef const T* const_iterator;
+    using value_type = T;
+    using iterator = T *;
+    using const_iterator = const T *;
 
     bool empty() const {
         return !is_set;

--- a/Rx/v2/src/rxcpp/schedulers/rx-currentthread.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-currentthread.hpp
@@ -15,13 +15,13 @@ namespace detail {
 
 struct action_queue
 {
-    typedef action_queue this_type;
+    using this_type = action_queue;
 
-    typedef scheduler_base::clock_type clock;
-    typedef time_schedulable<clock::time_point> item_type;
+    using clock = scheduler_base::clock_type;
+    using item_type = time_schedulable<clock::time_point>;
 
 private:
-    typedef schedulable_queue<item_type::time_point_type> queue_item_time;
+    using queue_item_time = schedulable_queue<item_type::time_point_type>;
 
 public:
     struct current_thread_queue_type {
@@ -131,15 +131,15 @@ public:
 struct current_thread : public scheduler_interface
 {
 private:
-    typedef current_thread this_type;
+    using this_type = current_thread;
     current_thread(const this_type&);
 
-    typedef detail::action_queue queue_type;
+    using queue_type = detail::action_queue;
 
     struct derecurser : public worker_interface
     {
     private:
-        typedef current_thread this_type;
+        using this_type = current_thread;
         derecurser(const this_type&);
     public:
         derecurser()
@@ -165,7 +165,7 @@ private:
     struct current_worker : public worker_interface
     {
     private:
-        typedef current_thread this_type;
+        using this_type = current_thread;
         current_worker(const this_type&);
     public:
         current_worker()

--- a/Rx/v2/src/rxcpp/schedulers/rx-eventloop.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-eventloop.hpp
@@ -14,19 +14,18 @@ namespace schedulers {
 struct event_loop : public scheduler_interface
 {
 private:
-    typedef event_loop this_type;
+    using this_type = event_loop;
     event_loop(const this_type&);
 
     struct loop_worker : public worker_interface
     {
     private:
-        typedef loop_worker this_type;
+        using this_type = loop_worker;
         loop_worker(const this_type&);
 
-        typedef detail::schedulable_queue<
-            typename clock_type::time_point> queue_item_time;
+        using queue_item_time = detail::schedulable_queue<typename clock_type::time_point>;
 
-        typedef queue_item_time::item_type item_type;
+        using item_type = queue_item_time::item_type;
 
         composite_subscription lifetime;
         worker controller;

--- a/Rx/v2/src/rxcpp/schedulers/rx-immediate.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-immediate.hpp
@@ -14,13 +14,13 @@ namespace schedulers {
 struct immediate : public scheduler_interface
 {
 private:
-    typedef immediate this_type;
+    using this_type = immediate;
     immediate(const this_type&);
 
     struct immediate_worker : public worker_interface
     {
     private:
-        typedef immediate_worker this_type;
+        using this_type = immediate_worker;
         immediate_worker(const this_type&);
     public:
         virtual ~immediate_worker()

--- a/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp
@@ -11,29 +11,28 @@ namespace rxcpp {
 
 namespace schedulers {
 
-typedef std::function<std::thread(std::function<void()>)> thread_factory;
+using thread_factory = std::function<std::thread(std::function<void()>)>;
 
 struct new_thread : public scheduler_interface
 {
 private:
-    typedef new_thread this_type;
+    using this_type = new_thread;
     new_thread(const this_type&);
 
     struct new_worker : public worker_interface
     {
     private:
-        typedef new_worker this_type;
+        using this_type = new_worker;
 
-        typedef detail::action_queue queue_type;
+        using queue_type = detail::action_queue;
 
         new_worker(const this_type&);
 
         struct new_worker_state : public std::enable_shared_from_this<new_worker_state>
         {
-            typedef detail::schedulable_queue<
-                typename clock_type::time_point> queue_item_time;
+            using queue_item_time = detail::schedulable_queue<typename clock_type::time_point>;
 
-            typedef queue_item_time::item_type item_type;
+            using item_type = queue_item_time::item_type;
 
             virtual ~new_worker_state()
             {

--- a/Rx/v2/src/rxcpp/schedulers/rx-runloop.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-runloop.hpp
@@ -15,13 +15,12 @@ namespace detail {
 
 struct run_loop_state : public std::enable_shared_from_this<run_loop_state>
 {
-    typedef scheduler::clock_type clock_type;
+    using clock_type = scheduler::clock_type;
 
-    typedef detail::schedulable_queue<
-        clock_type::time_point> queue_item_time;
+    using queue_item_time = detail::schedulable_queue<clock_type::time_point>;
 
-    typedef queue_item_time::item_type item_type;
-    typedef queue_item_time::const_reference const_reference_item_type;
+    using item_type = queue_item_time::item_type;
+    using const_reference_item_type = queue_item_time::const_reference;
 
     virtual ~run_loop_state()
     {
@@ -44,13 +43,13 @@ struct run_loop_state : public std::enable_shared_from_this<run_loop_state>
 struct run_loop_scheduler : public scheduler_interface
 {
 private:
-    typedef run_loop_scheduler this_type;
+    using this_type = run_loop_scheduler;
     run_loop_scheduler(const this_type&);
 
     struct run_loop_worker : public worker_interface
     {
     private:
-        typedef run_loop_worker this_type;
+        using this_type = run_loop_worker;
 
         run_loop_worker(const this_type&);
 
@@ -118,22 +117,22 @@ public:
 class run_loop
 {
 private:
-    typedef run_loop this_type;
+    using this_type = run_loop;
     // don't allow this instance to copy/move since it owns current_thread queue
     // for the thread it is constructed on.
     run_loop(const this_type&);
     run_loop(this_type&&);
 
-    typedef detail::action_queue queue_type;
+    using queue_type = detail::action_queue;
 
-    typedef detail::run_loop_state::item_type item_type;
-    typedef detail::run_loop_state::const_reference_item_type const_reference_item_type;
+    using item_type = detail::run_loop_state::item_type;
+    using const_reference_item_type = detail::run_loop_state::const_reference_item_type;
 
     std::shared_ptr<detail::run_loop_state> state;
     std::shared_ptr<run_loop_scheduler> sc;
 
 public:
-    typedef scheduler::clock_type clock_type;
+    using clock_type = scheduler::clock_type;
     run_loop()
         : state(std::make_shared<detail::run_loop_state>())
         , sc(std::make_shared<run_loop_scheduler>(state))

--- a/Rx/v2/src/rxcpp/schedulers/rx-sameworker.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-sameworker.hpp
@@ -14,7 +14,7 @@ namespace schedulers {
 struct same_worker : public scheduler_interface
 {
 private:
-    typedef same_worker this_type;
+    using this_type = same_worker;
     same_worker(const this_type&);
 
     rxsc::worker controller;

--- a/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
@@ -17,11 +17,11 @@ class test_type : public scheduler_interface
 {
 public:
 
-    typedef scheduler_interface::clock_type clock_type;
+    using clock_type = scheduler_interface::clock_type;
 
     struct test_type_state : public virtual_time<long, long>
     {
-        typedef virtual_time<long, long> base;
+        using base = virtual_time<long, long>;
 
         using base::schedule_absolute;
         using base::schedule_relative;
@@ -62,8 +62,8 @@ public:
     {
         mutable std::shared_ptr<test_type_state> state;
 
-        typedef test_type_state::absolute absolute;
-        typedef test_type_state::relative relative;
+        using absolute = test_type_state::absolute;
+        using relative = test_type_state::relative;
 
         test_type_worker(std::shared_ptr<test_type_state> st)
             : state(std::move(st))
@@ -160,8 +160,8 @@ template<class T>
 class mock_observer
     : public rxt::detail::test_subject_base<T>
 {
-    typedef typename rxn::notification<T> notification_type;
-    typedef rxn::recorded<typename notification_type::type> recorded_type;
+    using notification_type = typename rxn::notification<T>;
+    using recorded_type = rxn::recorded<typename notification_type::type>;
 
 public:
     explicit mock_observer(std::shared_ptr<test_type::test_type_state> sc)
@@ -187,8 +187,8 @@ public:
 template<class T>
 subscriber<T, rxt::testable_observer<T>> test_type::test_type_worker::make_subscriber() const
 {
-    typedef typename rxn::notification<T> notification_type;
-    typedef rxn::recorded<typename notification_type::type> recorded_type;
+    using  notification_type = typename rxn::notification<T>;
+    using  recorded_type = rxn::recorded<typename notification_type::type>;
 
     auto ts = std::make_shared<mock_observer<T>>(state);
 
@@ -217,9 +217,9 @@ template<class T>
 class cold_observable
     : public rxt::detail::test_subject_base<T>
 {
-    typedef cold_observable<T> this_type;
+    using  this_type = cold_observable<T>;
     std::shared_ptr<test_type::test_type_state> sc;
-    typedef rxn::recorded<typename rxn::notification<T>::type> recorded_type;
+    using  recorded_type = rxn::recorded<typename rxn::notification<T>::type>;
     mutable std::vector<recorded_type> mv;
     mutable std::vector<rxn::subscription> sv;
     mutable worker controller;
@@ -282,10 +282,10 @@ template<class T>
 class hot_observable
     : public rxt::detail::test_subject_base<T>
 {
-    typedef hot_observable<T> this_type;
+    using this_type = hot_observable<T>;
     std::shared_ptr<test_type::test_type_state> sc;
-    typedef rxn::recorded<typename rxn::notification<T>::type> recorded_type;
-    typedef subscriber<T> observer_type;
+    using recorded_type = rxn::recorded<typename rxn::notification<T>::type>;
+    using observer_type = subscriber<T>;
     mutable std::vector<recorded_type> mv;
     mutable std::vector<rxn::subscription> sv;
     mutable std::list<observer_type> observers;
@@ -370,7 +370,7 @@ public:
     {
     }
 
-    typedef detail::test_type::clock_type clock_type;
+    using clock_type = detail::test_type::clock_type;
 
     static const long created_time = 100;
     static const long subscribed_time = 200;
@@ -379,9 +379,9 @@ public:
     template<class T>
     struct messages
     {
-        typedef typename rxn::notification<T> notification_type;
-        typedef rxn::recorded<typename notification_type::type> recorded_type;
-        typedef rxn::subscription subscription_type;
+        using notification_type = typename rxn::notification<T>;
+        using recorded_type = rxn::recorded<typename notification_type::type>;
+        using subscription_type = rxn::subscription;
 
         messages() {}
 
@@ -469,7 +469,7 @@ public:
             struct state_type
             : public std::enable_shared_from_this<state_type>
             {
-                typedef decltype(createSource()) source_type;
+                using source_type = decltype(createSource());
 
                 std::unique_ptr<source_type> source;
                 subscriber<T, rxt::testable_observer<T>> o;
@@ -514,9 +514,9 @@ public:
         template<class F>
         struct start_traits
         {
-            typedef decltype(std::declval<F>()()) source_type;
-            typedef typename source_type::value_type value_type;
-            typedef subscriber<value_type, rxt::testable_observer<value_type>> subscriber_type;
+            using source_type = decltype(std::declval<F>()());
+            using value_type = typename source_type::value_type;
+            using subscriber_type = subscriber<value_type, rxt::testable_observer<value_type>>;
         };
 
         template<class F>

--- a/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
@@ -350,7 +350,7 @@ struct is_create_source_function
 {
     struct not_void {};
     template<class CF>
-    static auto check(int) -> decltype((*(CF*)nullptr)());
+    static auto check(int) -> decltype(std::declval<CF>()());
     template<class CF>
     static not_void check(...);
 
@@ -408,7 +408,7 @@ public:
     {
         std::shared_ptr<detail::test_type::test_type_worker> tester;
     public:
-        
+
         ~test_worker() {
         }
 
@@ -514,7 +514,7 @@ public:
         template<class F>
         struct start_traits
         {
-            typedef decltype((*(F*)nullptr)()) source_type;
+            typedef decltype(std::declval<F>()()) source_type;
             typedef typename source_type::value_type value_type;
             typedef subscriber<value_type, rxt::testable_observer<value_type>> subscriber_type;
         };

--- a/Rx/v2/src/rxcpp/schedulers/rx-virtualtime.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-virtualtime.hpp
@@ -17,14 +17,14 @@ template<class Absolute, class Relative>
 struct virtual_time_base : std::enable_shared_from_this<virtual_time_base<Absolute, Relative>>
 {
 private:
-    typedef virtual_time_base<Absolute, Relative> this_type;
+    using this_type = virtual_time_base<Absolute, Relative>;
     virtual_time_base(const virtual_time_base&);
 
     mutable bool isenabled;
 
 public:
-    typedef Absolute absolute;
-    typedef Relative relative;
+    using absolute = Absolute;
+    using relative = Relative;
 
     virtual ~virtual_time_base()
     {
@@ -44,7 +44,7 @@ protected:
 
     mutable absolute clock_now;
 
-    typedef time_schedulable<long> item_type;
+    using item_type = time_schedulable<long>;
 
     virtual absolute add(absolute, relative) const =0;
 
@@ -167,12 +167,11 @@ public:
 template<class Absolute, class Relative>
 struct virtual_time : public detail::virtual_time_base<Absolute, Relative>
 {
-    typedef detail::virtual_time_base<Absolute, Relative> base;
+    using base = detail::virtual_time_base<Absolute, Relative>;
 
-    typedef typename base::item_type item_type;
+    using item_type = typename base::item_type;
 
-    typedef detail::schedulable_queue<
-        typename item_type::time_point_type> queue_item_time;
+    using queue_item_time = detail::schedulable_queue<typename item_type::time_point_type>;
 
     mutable queue_item_time q;
 

--- a/Rx/v2/src/rxcpp/sources/rx-create.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-create.hpp
@@ -51,9 +51,9 @@ namespace detail {
 template<class T, class OnSubscribe>
 struct create : public source_base<T>
 {
-    typedef create<T, OnSubscribe> this_type;
+    using this_type = create<T, OnSubscribe>;
 
-    typedef rxu::decay_t<OnSubscribe> on_subscribe_type;
+    using on_subscribe_type = rxu::decay_t<OnSubscribe>;
 
     on_subscribe_type on_subscribe_function;
 

--- a/Rx/v2/src/rxcpp/sources/rx-defer.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-defer.hpp
@@ -32,7 +32,7 @@ template<class ObservableFactory>
 struct defer_traits
 {
     typedef rxu::decay_t<ObservableFactory> observable_factory_type;
-    typedef decltype((*(observable_factory_type*)nullptr)()) collection_type;
+    using collection_type = decltype(std::declval<observable_factory_type>()());
     typedef typename collection_type::value_type value_type;
 };
 

--- a/Rx/v2/src/rxcpp/sources/rx-defer.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-defer.hpp
@@ -31,19 +31,19 @@ namespace detail {
 template<class ObservableFactory>
 struct defer_traits
 {
-    typedef rxu::decay_t<ObservableFactory> observable_factory_type;
+    using observable_factory_type = rxu::decay_t<ObservableFactory>;
     using collection_type = decltype(std::declval<observable_factory_type>()());
-    typedef typename collection_type::value_type value_type;
+    using value_type = typename collection_type::value_type;
 };
 
 template<class ObservableFactory>
 struct defer : public source_base<rxu::value_type_t<defer_traits<ObservableFactory>>>
 {
-    typedef defer<ObservableFactory> this_type;
-    typedef defer_traits<ObservableFactory> traits;
+    using this_type = defer<ObservableFactory>;
+    using traits = defer_traits<ObservableFactory>;
 
-    typedef typename traits::observable_factory_type observable_factory_type;
-    typedef typename traits::collection_type collection_type;
+    using observable_factory_type = typename traits::observable_factory_type;
+    using collection_type = typename traits::collection_type;
 
     observable_factory_type observable_factory;
 

--- a/Rx/v2/src/rxcpp/sources/rx-error.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-error.hpp
@@ -115,15 +115,15 @@ namespace sources {
  */
 template<class T, class E>
 auto error(E e)
-    -> decltype(detail::make_error<T>(typename std::conditional<std::is_same<rxu::error_ptr, rxu::decay_t<E>>::value, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), identity_immediate())) {
-    return      detail::make_error<T>(typename std::conditional<std::is_same<rxu::error_ptr, rxu::decay_t<E>>::value, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), identity_immediate());
+    -> decltype(detail::make_error<T>(typename std::conditional<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), identity_immediate())) {
+    return      detail::make_error<T>(typename std::conditional<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), identity_immediate());
 }
 /*! @copydoc rx-error.hpp
  */
 template<class T, class E, class Coordination>
 auto error(E e, Coordination cn)
-    -> decltype(detail::make_error<T>(typename std::conditional<std::is_same<rxu::error_ptr, rxu::decay_t<E>>::value, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), std::move(cn))) {
-    return      detail::make_error<T>(typename std::conditional<std::is_same<rxu::error_ptr, rxu::decay_t<E>>::value, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), std::move(cn));
+    -> decltype(detail::make_error<T>(typename std::conditional<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), std::move(cn))) {
+    return      detail::make_error<T>(typename std::conditional<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), std::move(cn));
 }
 
 }

--- a/Rx/v2/src/rxcpp/sources/rx-error.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-error.hpp
@@ -115,15 +115,15 @@ namespace sources {
  */
 template<class T, class E>
 auto error(E e)
-    -> decltype(detail::make_error<T>(typename std::conditional<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), identity_immediate())) {
-    return      detail::make_error<T>(typename std::conditional<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), identity_immediate());
+    -> decltype(detail::make_error<T>(typename std::conditional_t<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), identity_immediate())) {
+    return      detail::make_error<T>(typename std::conditional_t<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), identity_immediate());
 }
 /*! @copydoc rx-error.hpp
  */
 template<class T, class E, class Coordination>
 auto error(E e, Coordination cn)
-    -> decltype(detail::make_error<T>(typename std::conditional<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), std::move(cn))) {
-    return      detail::make_error<T>(typename std::conditional<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>::type(), std::move(e), std::move(cn));
+    -> decltype(detail::make_error<T>(typename std::conditional_t<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), std::move(cn))) {
+    return      detail::make_error<T>(typename std::conditional_t<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), std::move(cn));
 }
 
 }

--- a/Rx/v2/src/rxcpp/sources/rx-error.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-error.hpp
@@ -38,11 +38,11 @@ namespace detail {
 template<class T, class Coordination>
 struct error : public source_base<T>
 {
-    typedef error<T, Coordination> this_type;
+    using this_type = error<T, Coordination>;
 
-    typedef rxu::decay_t<Coordination> coordination_type;
+    using coordination_type = rxu::decay_t<Coordination>;
 
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct error_initial_type
     {

--- a/Rx/v2/src/rxcpp/sources/rx-interval.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-interval.hpp
@@ -44,10 +44,10 @@ namespace detail {
 template<class Coordination>
 struct interval : public source_base<long>
 {
-    typedef interval<Coordination> this_type;
+    using this_type = interval<Coordination>;
 
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct interval_initial_type
     {

--- a/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
@@ -42,7 +42,7 @@ struct is_iterable
 
     struct not_void {};
     template<class CC>
-    static auto check(int) -> decltype(std::begin(*(CC*)nullptr));
+    static auto check(int) -> decltype(std::begin(std::declval<CC>()));
     template<class CC>
     static not_void check(...);
 
@@ -54,7 +54,7 @@ struct iterate_traits
 {
     // add const due to we don't want to modify original values!
     using collection_type = std::add_const_t<rxu::decay_t<Collection>>;
-    using iterator_type   = rxu::decay_t<decltype(std::begin(*(collection_type*)nullptr))>;
+    using iterator_type   = rxu::decay_t<decltype(std::begin(std::declval<collection_type>()))>;
     using value_type      = rxu::value_type_t<std::iterator_traits<iterator_type>>;
 };
 
@@ -228,7 +228,7 @@ auto from(Coordination cn)
 template<class Value0, class... ValueN>
 auto from(Value0&& v0, ValueN&&... vn)
     -> typename std::enable_if<!is_coordination<rxu::decay_t<Value0>>::value,
-        decltype(iterate(*(std::array<rxu::decay_t<Value0>, sizeof...(ValueN) + 1>*)nullptr, identity_immediate()))>::type {
+        decltype(iterate(std::declval<std::array<rxu::decay_t<Value0>, sizeof...(ValueN) + 1>>(), identity_immediate()))>::type {
     std::array<rxu::decay_t<Value0>, sizeof...(ValueN) + 1> c{{std::forward<Value0>(v0), std::forward<ValueN>(vn)...}};
     return iterate(std::move(c), identity_immediate());
 }
@@ -253,7 +253,7 @@ auto from(Value0&& v0, ValueN&&... vn)
 template<class Coordination, class Value0, class... ValueN>
 auto from(Coordination cn, Value0&& v0, ValueN&&... vn)
     -> typename std::enable_if<is_coordination<Coordination>::value,
-        decltype(iterate(*(std::array<rxu::decay_t<Value0>, sizeof...(ValueN) + 1>*)nullptr, std::move(cn)))>::type {
+        decltype(iterate(std::declval<std::array<rxu::decay_t<Value0>, sizeof...(ValueN) + 1>>(), std::move(cn)))>::type {
     std::array<rxu::decay_t<Value0>, sizeof...(ValueN) + 1> c{{std::forward<Value0>(v0), std::forward<ValueN>(vn)...}};
     return iterate(std::move(c), std::move(cn));
 }
@@ -274,7 +274,7 @@ auto from(Coordination cn, Value0&& v0, ValueN&&... vn)
 template<class Value0>
 auto just(Value0&& v0)
     -> typename std::enable_if<!is_coordination<rxu::decay_t<Value0>>::value,
-        decltype(iterate(*(std::array<rxu::decay_t<Value0>, 1>*)nullptr, identity_immediate()))>::type {
+        decltype(iterate(std::declval<std::array<rxu::decay_t<Value0>, 1>>(), identity_immediate()))>::type {
     std::array<rxu::decay_t<Value0>, 1> c{{std::forward<Value0>(v0)}};
     return iterate(std::move(c), identity_immediate());
 }
@@ -295,7 +295,7 @@ auto just(Value0&& v0)
 template<class Value0, class Coordination>
 auto just(Value0&& v0, Coordination cn)
     -> typename std::enable_if<is_coordination<Coordination>::value,
-        decltype(iterate(*(std::array<rxu::decay_t<Value0>, 1>*)nullptr, std::move(cn)))>::type {
+        decltype(iterate(std::declval<std::array<rxu::decay_t<Value0>, 1>>(), std::move(cn)))>::type {
     std::array<rxu::decay_t<Value0>, 1> c{{std::forward<Value0>(v0)}};
     return iterate(std::move(c), std::move(cn));
 }

--- a/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
@@ -46,7 +46,7 @@ struct is_iterable
     template<class CC>
     static not_void check(...);
 
-    static const bool value = !std::is_same<decltype(check<collection_type>(0)), not_void>::value;
+    static const bool value = !std::is_same_v<decltype(check<collection_type>(0)), not_void>;
 };
 
 template<class Collection>

--- a/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
@@ -38,7 +38,7 @@ namespace detail {
 template<class Collection>
 struct is_iterable
 {
-    typedef rxu::decay_t<Collection> collection_type;
+    using collection_type = rxu::decay_t<Collection>;
 
     struct not_void {};
     template<class CC>
@@ -96,7 +96,7 @@ struct iterate : public source_base<rxu::value_type_t<iterate_traits<Collection>
     void on_subscribe(Subscriber o) const {
         static_assert(is_subscriber<Subscriber>::value, "subscribe must be passed a subscriber");
 
-        typedef typename coordinator_type::template get<Subscriber>::type output_type;
+        using output_type = typename coordinator_type::template get<Subscriber>::type;
 
         struct iterate_state_type
             : public iterate_initial_type

--- a/Rx/v2/src/rxcpp/sources/rx-range.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-range.hpp
@@ -39,8 +39,8 @@ namespace detail {
 template<class T, class Coordination>
 struct range : public source_base<T>
 {
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct range_state_type
     {

--- a/Rx/v2/src/rxcpp/sources/rx-scope.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-scope.hpp
@@ -33,11 +33,11 @@ namespace detail {
 template<class ResourceFactory, class ObservableFactory>
 struct scope_traits
 {
-    typedef rxu::decay_t<ResourceFactory> resource_factory_type;
-    typedef rxu::decay_t<ObservableFactory> observable_factory_type;
+    using resource_factory_type = rxu::decay_t<ResourceFactory>;
+    using observable_factory_type = rxu::decay_t<ObservableFactory>;
     using resource_type = decltype((std::declval<resource_factory_type>())());
     using collection_type = decltype(std::declval<observable_factory_type>()(resource_type()));
-    typedef typename collection_type::value_type value_type;
+    using value_type = typename collection_type::value_type;
 
     static_assert(is_subscription<resource_type>::value, "ResourceFactory must return a subscription");
 };
@@ -45,11 +45,11 @@ struct scope_traits
 template<class ResourceFactory, class ObservableFactory>
 struct scope : public source_base<rxu::value_type_t<scope_traits<ResourceFactory, ObservableFactory>>>
 {
-    typedef scope_traits<ResourceFactory, ObservableFactory> traits;
-    typedef typename traits::resource_factory_type resource_factory_type;
-    typedef typename traits::observable_factory_type observable_factory_type;
-    typedef typename traits::resource_type resource_type;
-    typedef typename traits::value_type value_type;
+    using traits = scope_traits<ResourceFactory, ObservableFactory>;
+    using resource_factory_type = typename traits::resource_factory_type;
+    using observable_factory_type = typename traits::observable_factory_type;
+    using resource_type = typename traits::resource_type;
+    using value_type = typename traits::value_type;
 
     struct values
     {

--- a/Rx/v2/src/rxcpp/sources/rx-scope.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-scope.hpp
@@ -35,8 +35,8 @@ struct scope_traits
 {
     typedef rxu::decay_t<ResourceFactory> resource_factory_type;
     typedef rxu::decay_t<ObservableFactory> observable_factory_type;
-    typedef decltype((*(resource_factory_type*)nullptr)()) resource_type;
-    typedef decltype((*(observable_factory_type*)nullptr)(resource_type())) collection_type;
+    using resource_type = decltype((std::declval<resource_factory_type>())());
+    using collection_type = decltype(std::declval<observable_factory_type>()(resource_type()));
     typedef typename collection_type::value_type value_type;
 
     static_assert(is_subscription<resource_type>::value, "ResourceFactory must return a subscription");

--- a/Rx/v2/src/rxcpp/sources/rx-timer.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-timer.hpp
@@ -44,10 +44,10 @@ namespace detail {
 template<class Coordination>
 struct timer : public source_base<long>
 {
-    typedef timer<Coordination> this_type;
+    using this_type = timer<Coordination>;
 
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 
     struct timer_initial_type
     {

--- a/Rx/v2/src/rxcpp/subjects/rx-behavior.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-behavior.hpp
@@ -16,8 +16,8 @@ namespace detail {
 template<class T>
 class behavior_observer : public detail::multicast_observer<T>
 {
-    typedef behavior_observer<T> this_type;
-    typedef detail::multicast_observer<T> base_type;
+    using this_type = behavior_observer<T>;
+    using base_type = detail::multicast_observer<T>;
 
     class behavior_observer_state : public std::enable_shared_from_this<behavior_observer_state>
     {

--- a/Rx/v2/src/rxcpp/subjects/rx-replaysubject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-replaysubject.hpp
@@ -16,25 +16,25 @@ namespace detail {
 template<class Coordination>
 struct replay_traits
 {
-    typedef rxu::maybe<std::size_t> count_type;
-    typedef rxu::maybe<rxsc::scheduler::clock_type::duration> period_type;
-    typedef rxsc::scheduler::clock_type::time_point time_point_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
+    using count_type = rxu::maybe<std::size_t>;
+    using period_type = rxu::maybe<rxsc::scheduler::clock_type::duration>;
+    using time_point_type = rxsc::scheduler::clock_type::time_point;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
 };
 
 template<class T, class Coordination>
 class replay_observer : public detail::multicast_observer<T>
 {
-    typedef replay_observer<T, Coordination> this_type;
-    typedef detail::multicast_observer<T> base_type;
+    using this_type = replay_observer<T, Coordination>;
+    using base_type = detail::multicast_observer<T>;
 
-    typedef replay_traits<Coordination> traits;
-    typedef typename traits::count_type count_type;
-    typedef typename traits::period_type period_type;
-    typedef typename traits::time_point_type time_point_type;
-    typedef typename traits::coordination_type coordination_type;
-    typedef typename traits::coordinator_type coordinator_type;
+    using traits = replay_traits<Coordination>;
+    using count_type = typename traits::count_type;
+    using period_type = typename traits::period_type;
+    using time_point_type = typename traits::time_point_type;
+    using coordination_type = typename traits::coordination_type;
+    using coordinator_type = typename traits::coordinator_type;
 
     class replay_observer_state : public std::enable_shared_from_this<replay_observer_state>
     {
@@ -126,10 +126,10 @@ public:
 template<class T, class Coordination>
 class replay
 {
-    typedef detail::replay_traits<Coordination> traits;
-    typedef typename traits::count_type count_type;
-    typedef typename traits::period_type period_type;
-    typedef typename traits::time_point_type time_point_type;
+    using traits = detail::replay_traits<Coordination>;
+    using count_type = typename traits::count_type;
+    using period_type = typename traits::period_type;
+    using time_point_type = typename traits::time_point_type;
 
     detail::replay_observer<T, Coordination> s;
 

--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -16,8 +16,8 @@ namespace detail {
 template<class T>
 class multicast_observer
 {
-    typedef subscriber<T> observer_type;
-    typedef std::vector<observer_type> list_type;
+    using observer_type = subscriber<T>;
+    using list_type = std::vector<observer_type>;
 
     struct mode
     {
@@ -100,7 +100,7 @@ class multicast_observer
     std::shared_ptr<binder_type> b;
 
 public:
-    typedef subscriber<T, observer<T, detail::multicast_observer<T>>> input_subscriber_type;
+    using input_subscriber_type = subscriber <T, observer<T, detail::multicast_observer<T>>>;
 
     explicit multicast_observer(composite_subscription cs)
         : b(std::make_shared<binder_type>(cs))
@@ -238,8 +238,8 @@ class subject
     detail::multicast_observer<T> s;
 
 public:
-    typedef subscriber<T, observer<T, detail::multicast_observer<T>>> subscriber_type;
-    typedef observable<T> observable_type;
+    using subscriber_type = subscriber <T, observer<T, detail::multicast_observer<T>>>;
+    using observable_type = observable<T>;
     subject()
         : s(composite_subscription())
     {

--- a/Rx/v2/src/rxcpp/subjects/rx-synchronize.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-synchronize.hpp
@@ -16,18 +16,18 @@ namespace detail {
 template<class T, class Coordination>
 class synchronize_observer : public detail::multicast_observer<T>
 {
-    typedef synchronize_observer<T, Coordination> this_type;
-    typedef detail::multicast_observer<T> base_type;
+    using this_type = synchronize_observer<T, Coordination>;
+    using base_type = detail::multicast_observer<T>;
 
-    typedef rxu::decay_t<Coordination> coordination_type;
-    typedef typename coordination_type::coordinator_type coordinator_type;
-    typedef typename coordinator_type::template get<subscriber<T>>::type output_type;
+    using coordination_type = rxu::decay_t<Coordination>;
+    using coordinator_type = typename coordination_type::coordinator_type;
+    using output_type = typename coordinator_type::template get<subscriber < T>>::type;
 
     struct synchronize_observer_state : public std::enable_shared_from_this<synchronize_observer_state>
     {
-        typedef rxn::notification<T> notification_type;
-        typedef typename notification_type::type base_notification_type;
-        typedef std::deque<base_notification_type> queue_type;
+        using notification_type = rxn::notification<T>;
+        using base_notification_type = typename notification_type::type;
+        using queue_type = std::deque<base_notification_type>;
 
         struct mode
         {
@@ -236,7 +236,7 @@ public:
 
     explicit synchronize_in_one_worker(rxsc::scheduler sc) : factory(sc) {}
 
-    typedef coordinator<input_type> coordinator_type;
+    using coordinator_type = coordinator<input_type>;
 
     inline rxsc::scheduler::clock_type::time_point now() const {
         return factory.now();


### PR DESCRIPTION
First of all: thanks for RxCpp and the great work you put into it! 
It's a really neat and useful library and I wonder why it isn't already part of the C++ standard! :+1:

This PR primarily addresses issue #570 and replaces pointer-type casting which causes warnings and (w/ `-Werror`) errors on newer compilers.

While refactoring, I noticed that some structures appear rather old (pre C++11) and could be simplified which I hope may help readability, modernizing towards C++20 (if this isn't excluded), and help new developers. Some of the low-hanging fruits (w/o breaking the apparent <=C++14 constraint) were:
  * updated Catch2 to v2.13.8 (216713a) - the old version isn't compatible anymore with more modern OSes.
  * replacing C-style typedef type aliasing by 'using type = ' see also [C++ Core Guidelines - T.43](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rt-using)
N.B. this should make later refactoring (and possible introduction of 'concepts') a bit easier ...
  * replaced `std::is_same<...>::value` by `std::is_same_v<...>`
  * replaced `std::conditional<...>::type` by `std::conditional_t<...>`

I didn't tackle the ubiquitous `std::enable_if<...>::type` by `std::enable_if_t<...>` simplification and swapping of confusing ternary statements because of the sheer number of lines that would be impacted and because many of these lines wouldn't probably be needed anymore if this library would adopt C++20 and concepts (see also [C++ Core Guidelines - T.48](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#t48-if-your-compiler-does-not-support-concepts-fake-them-with-enable_if)).

Let me know what you think and hope this fits the coding standard and style this library aims for.