### PR TITLE
Fix typo in linesfrombytes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ int main()
                     }) |
                 as_dynamic();
         }) |
-        tap([](vector<uint8_t>& v){
+        tap([](const vector<uint8_t>& v){
             // print input packet of bytes
             copy(v.begin(), v.end(), ostream_iterator<long>(cout, " "));
             cout << endl;


### PR DESCRIPTION
@kirkshoop ,
I found a typo in linesfrombytes example in README.md file.
This example is not compiled in gcc and clang. But @victimsnino already fixed this problem in Rx/v2/examples/linesfrombytes!