### PR TITLE
Add missing CMake variables for building tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,14 @@ RxCpp uses CMake to create build files for several platforms and IDE's
 ```shell
 mkdir projects/build
 cd projects/build
-cmake -G"Xcode" ../CMake -B.
+cmake -G"Xcode" -DRXCPP_DISABLE_TESTS_AND_EXAMPLES=0 ../CMake -B.
 ```
 
 #### Visual Studio 2017
 ```batch
 mkdir projects\build
 cd projects\build
-cmake -G "Visual Studio 15" ..\CMake\
+cmake -G "Visual Studio 15" -DRXCPP_DISABLE_TESTS_AND_EXAMPLES=0 ..\CMake\
 msbuild Project.sln
 ```
 
@@ -209,7 +209,7 @@ msbuild Project.sln
 ```shell
 mkdir projects/build
 cd projects/build
-cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -B. ../CMake
+cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRXCPP_DISABLE_TESTS_AND_EXAMPLES=0 -B. ../CMake
 make
 ```
 
@@ -217,7 +217,7 @@ make
 ```shell
 mkdir projects/build
 cd projects/build
-cmake -G"Unix Makefiles" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -B. ../CMake
+cmake -G"Unix Makefiles" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -DRXCPP_DISABLE_TESTS_AND_EXAMPLES=0 -B. ../CMake
 make
 ```
 
@@ -225,7 +225,7 @@ make
 ```shell
 mkdir projects/build
 cd projects/build
-cmake -G"Unix Makefiles" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -B. ../CMake
+cmake -G"Unix Makefiles" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRXCPP_DISABLE_TESTS_AND_EXAMPLES=0 -B. ../CMake
 make
 ```
 
@@ -233,7 +233,7 @@ make
 ```batch
 mkdir projects\build
 cd projects\build
-cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -B. ..\CMake
+cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRXCPP_DISABLE_TESTS_AND_EXAMPLES=0 -B. ..\CMake
 nmake
 ```
 


### PR DESCRIPTION
@kirkshoop ,
I followed instructions in the Readme document to build unit tests but I couldn't get them.

@ivan-cukic added disable building tests option in CMakeLists.txt. I think instructions for building unit tests in the Readme document was not updated with this changes.