### PR TITLE
Include headers directory as SYSTEM path

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -153,10 +153,17 @@ install(DIRECTORY ${RXCPP_DIR}/Rx/v2/src/rxcpp/ DESTINATION include/rxcpp
 # just with find_package(rxcpp CONFIG) after rxcpp is installed into system by "make install". 
 add_library(rxcpp INTERFACE)
 
-target_include_directories(rxcpp INTERFACE
-    $<BUILD_INTERFACE:${RXCPP_DIR}/Rx/v2/src/>
-    $<INSTALL_INTERFACE:include/rxcpp>
-)
+if (RXCPP_INCLUDE_AS_SYSTEM_HEADERS) # Include as system header to not cause warnings when used as cmake subproject
+   target_include_directories(rxcpp SYSTEM INTERFACE
+       $<BUILD_INTERFACE:${RXCPP_DIR}/Rx/v2/src/>
+       $<INSTALL_INTERFACE:include/rxcpp>
+   )
+else (RXCPP_INCLUDE_AS_SYSTEM_HEADERS) # include as private headers to have warnings for examples and tests
+   target_include_directories(rxcpp INTERFACE
+       $<BUILD_INTERFACE:${RXCPP_DIR}/Rx/v2/src/>
+       $<INSTALL_INTERFACE:include/rxcpp>
+   )
+endif (RXCPP_INCLUDE_AS_SYSTEM_HEADERS)
 
 install(TARGETS rxcpp EXPORT rxcppConfig)
 install(EXPORT rxcppConfig DESTINATION share/rxcpp/cmake)


### PR DESCRIPTION
When using the `rxcpp` target from a cmake subproject (using fetch_content or add_subdirectory) it is not possible to use `-Werror` or stricter warnings in general due to warnings from the rxcpp headers being reported. This change sets the `SYSTEM` flag only if the variable `RXCPP_INCLUDE_AS_SYSTEM_HEADERS` is set to true. In the end this passes the include directories to gcc using the `-i` flag instead of the `-I` flag and warnings from the rxcpp headers are not reported in projects including it. SYSTEM has to be set conditonally because that would also suppress valid warnings for the rxcpp tests and examples.

See https://www.foonathan.net/2018/10/cmake-warnings/ for a nice writeup of handling warings for header only cmake projects.