### PR TITLE
enforce C++14 in cmake + added rxcpp::is_same_v C++14 compatible definition ...

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
@@ -68,7 +68,7 @@ struct is_combine_latest_selector_check {
 
     using type = decltype(check<selector_type, rxu::decay_t<ObservableN>...>(0));
 
-    static const bool value = !std::is_same_v<type, tag_not_valid>;
+    static const bool value = !rxcpp::is_same_v<type, tag_not_valid>;
 };
 
 template<class Selector, class... ObservableN>

--- a/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
@@ -64,7 +64,7 @@ struct concat_traits {
     template<class CV, class CCS>
     static tag_not_valid collection_check(...);
 
-    static_assert(!std::is_same_v<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>, "concat_map CollectionSelector must be a function with the signature observable(concat_map::source_value_type)");
+    static_assert(!rxcpp::is_same_v<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>, "concat_map CollectionSelector must be a function with the signature observable(concat_map::source_value_type)");
 
     using collection_type = decltype(std::declval<collection_selector_type>()((*(source_value_type *) nullptr)));
 
@@ -79,7 +79,7 @@ struct concat_traits {
     template<class CV, class CCV, class CRS>
     static tag_not_valid result_check(...);
 
-    static_assert(!std::is_same_v<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>, "concat_map ResultSelector must be a function with the signature concat_map::value_type(concat_map::source_value_type, concat_map::collection_value_type)");
+    static_assert(!rxcpp::is_same_v<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>, "concat_map ResultSelector must be a function with the signature concat_map::value_type(concat_map::source_value_type, concat_map::collection_value_type)");
 
     using value_type = rxu::decay_t<decltype(std::declval<result_selector_type>()(std::declval<source_value_type>(), std::declval<collection_value_type>()))> ;
 };

--- a/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
@@ -64,7 +64,7 @@ struct flat_map_traits {
     template<class CV, class CCS>
     static tag_not_valid collection_check(...);
 
-    static_assert(!std::is_same_v<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>, "flat_map CollectionSelector must be a function with the signature observable(flat_map::source_value_type)");
+    static_assert(!rxcpp::is_same_v<decltype(collection_check<source_value_type, collection_selector_type>(0)), tag_not_valid>, "flat_map CollectionSelector must be a function with the signature observable(flat_map::source_value_type)");
 
     using collection_type = rxu::decay_t<decltype(std::declval<collection_selector_type>()(std::declval<source_value_type>()))>;
 
@@ -77,7 +77,7 @@ struct flat_map_traits {
     template<class CV, class CCV, class CRS>
     static tag_not_valid result_check(...);
 
-    static_assert(!std::is_same_v<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>, "flat_map ResultSelector must be a function with the signature flat_map::value_type(flat_map::source_value_type, flat_map::collection_value_type)");
+    static_assert(!rxcpp::is_same_v<decltype(result_check<source_value_type, collection_value_type, result_selector_type>(0)), tag_not_valid>, "flat_map ResultSelector must be a function with the signature flat_map::value_type(flat_map::source_value_type, flat_map::collection_value_type)");
 
     using value_type = rxu::decay_t<decltype((std::declval<result_selector_type>())(std::declval<source_value_type>(), std::declval<collection_value_type>()))> ;
 };

--- a/Rx/v2/src/rxcpp/operators/rx-group_by.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-group_by.hpp
@@ -61,7 +61,7 @@ struct is_group_by_selector_for {
     static tag_not_valid check(...);
 
     using type = decltype(check<source_value_type, selector_type>(0));
-    static const bool value = !std::is_same_v<type, tag_not_valid>;
+    static const bool value = !rxcpp::is_same_v<type, tag_not_valid>;
 };
 
 template<class T, class Observable, class KeySelector, class MarbleSelector, class BinaryPredicate, class DurationSelector>

--- a/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
@@ -78,7 +78,7 @@ struct is_result_function_for {
     static tag_not_valid check(...);
 
     using type = rxu::decay_t<decltype(check<seed_type, result_selector_type>(0))>;
-    static const bool value = !std::is_same_v<type, tag_not_valid>;
+    static const bool value = !rxcpp::is_same_v<type, tag_not_valid>;
 };
 
 template<class T, class Observable, class Accumulator, class ResultSelector, class Seed>

--- a/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
@@ -68,7 +68,7 @@ struct is_with_latest_from_selector_check {
 
     using type = decltype(check<selector_type, rxu::decay_t<ObservableN>...>(0));
 
-    static const bool value = !std::is_same_v<type, tag_not_valid>;
+    static const bool value = !rxcpp::is_same_v<type, tag_not_valid>;
 };
 
 template<class Selector, class... ObservableN>

--- a/Rx/v2/src/rxcpp/operators/rx-zip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-zip.hpp
@@ -103,7 +103,7 @@ struct is_zip_selector_check {
 
     using type = decltype(check<selector_type, rxu::decay_t<ObservableN>...>(0));
 
-    static const bool value = !std::is_same_v<type, tag_not_valid>;
+    static const bool value = !rxcpp::is_same_v<type, tag_not_valid>;
 };
 
 template<class Selector, class... ObservableN>

--- a/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
@@ -21,7 +21,7 @@ struct has_on_connect
     static not_void check(...);
 
     using detail_result = decltype(check<T>(0));
-    static const bool value = std::is_same_v<detail_result, void>;
+    static const bool value = rxcpp::is_same_v<detail_result, void>;
 };
 
 }

--- a/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
@@ -21,7 +21,7 @@ struct has_on_get_key_for
     static not_void check(...);
 
     using detail_result = decltype(check<Source>(0));
-    static const bool value = std::is_same_v<detail_result, rxu::decay_t<K>>;
+    static const bool value = rxcpp::is_same_v<detail_result, rxu::decay_t<K>>;
 };
 
 }

--- a/Rx/v2/src/rxcpp/rx-notification.hpp
+++ b/Rx/v2/src/rxcpp/rx-notification.hpp
@@ -229,7 +229,7 @@ public:
 
     template<typename Exception>
     static type on_error(Exception&& e) {
-        return make_on_error(typename std::conditional_t<std::is_same_v<rxu::decay_t<Exception>, rxu::error_ptr>, exception_ptr_tag, exception_tag>(), std::forward<Exception>(e));
+        return make_on_error(typename std::conditional_t<rxcpp::is_same_v<rxu::decay_t<Exception>, rxu::error_ptr>, exception_ptr_tag, exception_tag>(), std::forward<Exception>(e));
     }
 };
 

--- a/Rx/v2/src/rxcpp/rx-observable-fwd.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable-fwd.hpp
@@ -14,7 +14,7 @@ class dynamic_observable;
 
 template<
     class T = void,
-    class SourceObservable = typename std::conditional_t<std::is_same_v<T, void>, void, dynamic_observable<T>>>
+    class SourceObservable = typename std::conditional_t<rxcpp::is_same_v<T, void>, void, dynamic_observable<T>>>
 class observable;
 
 template<class T, class Source>

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -27,7 +27,7 @@ struct has_on_subscribe_for
     static not_void check(...);
 
     using detail_result = decltype(check<rxu::decay_t < Subscriber>, T > (0));
-    static const bool value = std::is_same_v<detail_result, void>;
+    static const bool value = rxcpp::is_same_v<detail_result, void>;
 };
 
 }
@@ -478,7 +478,7 @@ template<class T, class SourceOperator>
 class observable
     : public observable_base<T>
 {
-    static_assert(std::is_same_v<T, typename SourceOperator::value_type>, "SourceOperator::value_type must be the same as T in observable<T, SourceOperator>");
+    static_assert(rxcpp::is_same_v<T, typename SourceOperator::value_type>, "SourceOperator::value_type must be the same as T in observable<T, SourceOperator>");
 
     using this_type = observable<T, SourceOperator>;
 
@@ -501,7 +501,7 @@ private:
         using subscriber_type = rxu::decay_t<Subscriber>;
 
         static_assert(is_subscriber<subscriber_type>::value, "subscribe must be passed a subscriber");
-        static_assert(std::is_same_v<typename source_operator_type::value_type, T> && std::is_convertible<T*, typename subscriber_type::value_type*>::value, "the value types in the sequence must match or be convertible");
+        static_assert(rxcpp::is_same_v<typename source_operator_type::value_type, T> && std::is_convertible<T*, typename subscriber_type::value_type*>::value, "the value types in the sequence must match or be convertible");
         static_assert(detail::has_on_subscribe_for<subscriber_type, source_operator_type>::value, "inner must have on_subscribe method that accepts this subscriber ");
 
         trace_activity().subscribe_enter(*this, o);

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -121,7 +121,7 @@ struct is_on_next_of
     static not_void check(...);
 
     using detail_result = decltype(check<T, rxu::decay_t < F>>(0));
-    static const bool value = std::is_same_v<detail_result, void>;
+    static const bool value = rxcpp::is_same_v<detail_result, void>;
 };
 
 template<class F>
@@ -133,7 +133,7 @@ struct is_on_error
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
+    static const bool value = rxcpp::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 template<class State, class F>
@@ -145,7 +145,7 @@ struct is_on_error_for
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
+    static const bool value = rxcpp::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 template<class F>
@@ -157,7 +157,7 @@ struct is_on_completed
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
+    static const bool value = rxcpp::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 }
@@ -181,9 +181,9 @@ class observer : public observer_base<T>
 public:
     using this_type = observer<T, State, OnNext, OnError, OnCompleted>;
     using state_t = rxu::decay_t<State>;
-    using on_next_t = typename std::conditional_t<!std::is_same_v<void, OnNext>, rxu::decay_t<OnNext>, detail::OnNextForward<T, State, OnNext>>;
-    using on_error_t = typename std::conditional_t<!std::is_same_v<void, OnError>, rxu::decay_t<OnError>, detail::OnErrorForward<State, OnError>>;
-    using on_completed_t = typename std::conditional_t<!std::is_same_v<void, OnCompleted>, rxu::decay_t<OnCompleted>, detail::OnCompletedForward<State, OnCompleted>>;
+    using on_next_t = typename std::conditional_t<!rxcpp::is_same_v<void, OnNext>, rxu::decay_t<OnNext>, detail::OnNextForward<T, State, OnNext>>;
+    using on_error_t = typename std::conditional_t<!rxcpp::is_same_v<void, OnError>, rxu::decay_t<OnError>, detail::OnErrorForward<State, OnError>>;
+    using on_completed_t = typename std::conditional_t<!rxcpp::is_same_v<void, OnCompleted>, rxu::decay_t<OnCompleted>, detail::OnCompletedForward<State, OnCompleted>>;
 
 private:
     mutable state_t state;
@@ -261,9 +261,9 @@ class observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted> 
 {
 public:
     using this_type = observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>;
-    using on_next_t = typename std::conditional_t<!std::is_same_v<void, OnNext>, rxu::decay_t<OnNext>, detail::OnNextEmpty<T>>;
-    using on_error_t = typename std::conditional_t<!std::is_same_v<void, OnError>, rxu::decay_t<OnError>, detail::OnErrorEmpty>;
-    using on_completed_t = typename std::conditional_t<!std::is_same_v<void, OnCompleted>, rxu::decay_t<OnCompleted>, detail::OnCompletedEmpty>;
+    using on_next_t = typename std::conditional_t<!rxcpp::is_same_v<void, OnNext>, rxu::decay_t<OnNext>, detail::OnNextEmpty<T>>;
+    using on_error_t = typename std::conditional_t<!rxcpp::is_same_v<void, OnError>, rxu::decay_t<OnError>, detail::OnErrorEmpty>;
+    using on_completed_t = typename std::conditional_t<!rxcpp::is_same_v<void, OnCompleted>, rxu::decay_t<OnCompleted>, detail::OnCompletedEmpty>;
 
 private:
     on_next_t onnext;

--- a/Rx/v2/src/rxcpp/rx-predef.hpp
+++ b/Rx/v2/src/rxcpp/rx-predef.hpp
@@ -202,7 +202,7 @@ template<class T>
 class dynamic_connectable_observable;
 
 template<class T,
-    class SourceObservable = typename std::conditional_t<std::is_same_v<T, void>, void, dynamic_connectable_observable<T>>>
+    class SourceObservable = typename std::conditional_t<rxcpp::is_same_v<T, void>, void, dynamic_connectable_observable<T>>>
 class connectable_observable;
 
 struct tag_connectable_observable : public tag_observable {};
@@ -235,7 +235,7 @@ template<class K, class T>
 class dynamic_grouped_observable;
 
 template<class K, class T,
-    class SourceObservable = typename std::conditional_t<std::is_same_v<T, void>, void, dynamic_grouped_observable<K, T>>>
+    class SourceObservable = typename std::conditional_t<rxcpp::is_same_v<T, void>, void, dynamic_grouped_observable<K, T>>>
 class grouped_observable;
 
 template<class K, class T, class Source>
@@ -268,7 +268,7 @@ struct is_operator_factory_for {
 
     using type = decltype(check<function_type, source_type>(0));
 
-    static const bool value = !std::is_same_v<type, tag_not_valid> && is_observable<source_type>::value;
+    static const bool value = !rxcpp::is_same_v<type, tag_not_valid> && is_observable<source_type>::value;
 };
 
 //
@@ -307,7 +307,7 @@ struct is_accumulate_function_for {
     static tag_not_valid check(...);
 
     using type = decltype(check<seed_type, source_value_type, accumulator_type>(0));
-    static const bool value = std::is_same_v<type, seed_type>;
+    static const bool value = rxcpp::is_same_v<type, seed_type>;
 };
 
 }

--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -187,7 +187,7 @@ struct is_action_function
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
+    static const bool value = rxcpp::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 }

--- a/Rx/v2/src/rxcpp/rx-subscriber.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscriber.hpp
@@ -124,8 +124,8 @@ public:
     subscriber(
         const subscriber<T, O>& o,
         typename std::enable_if<
-               !std::is_same_v<O, observer<T>> &&
-               std::is_same_v<Observer, observer<T>>, void**>::type = nullptr)
+               !rxcpp::is_same_v<O, observer<T>> &&
+               rxcpp::is_same_v<Observer, observer<T>>, void**>::type = nullptr)
         : lifetime(o.lifetime)
         , destination(o.destination.as_dynamic())
         , id(o.id)

--- a/Rx/v2/src/rxcpp/rx-subscription.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscription.hpp
@@ -20,7 +20,7 @@ struct is_unsubscribe_function
     template<class CF>
     static not_void check(...);
 
-    static const bool value = std::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
+    static const bool value = rxcpp::is_same_v<decltype(check<rxu::decay_t<F>>(0)), void>;
 };
 
 }
@@ -143,7 +143,7 @@ public:
         }
     }
     template<class U>
-    explicit subscription(U u, typename std::enable_if<!std::is_same_v<subscription, U> && is_subscription<U>::value, void**>::type = nullptr)
+    explicit subscription(U u, typename std::enable_if<!rxcpp::is_same_v<subscription, U> && is_subscription<U>::value, void**>::type = nullptr)
         // intentionally slice
         : state(std::move((*static_cast<subscription*>(&u)).state))
     {

--- a/Rx/v2/src/rxcpp/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/rx-test.hpp
@@ -38,7 +38,7 @@ struct test_source
         ts->on_subscribe(std::move(o));
     }
     template<class Subscriber>
-    typename std::enable_if<!std::is_same_v<Subscriber, subscriber<T>>, void>::type
+    typename std::enable_if<!rxcpp::is_same_v<Subscriber, subscriber<T>>, void>::type
     on_subscribe(Subscriber o) const {
 
         static_assert(is_subscriber<Subscriber>::value, "on_subscribe must be passed a subscriber.");

--- a/Rx/v2/src/rxcpp/rx-trace.hpp
+++ b/Rx/v2/src/rxcpp/rx-trace.hpp
@@ -111,4 +111,28 @@ struct trace_tag {};
 inline auto rxcpp_trace_activity(...) -> rxcpp::trace_noop;
 
 
+#if __cplusplus <= 201402L
+// intermediate C++14 hort-hand definitions anticipating those available in C++17 onwards
+namespace rxcpp {
+template<class T, class U>
+static constexpr bool is_same_v = false;
+
+template<class T>
+static constexpr bool is_same_v<T, T> = true;
+
+} // namespace rxcpp
+
+#else
+
+namespace rxcpp {
+template <typename _Tp, typename _Up>
+inline constexpr bool is_same_v = std::is_same_v<_Tp, _Up>;
+
+} // namespace rxcpp
+#endif
+
+static_assert(rxcpp::is_same_v<int,int>);
+static_assert(!rxcpp::is_same_v<int,float>);
+
+
 #endif

--- a/Rx/v2/src/rxcpp/sources/rx-error.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-error.hpp
@@ -115,15 +115,15 @@ namespace sources {
  */
 template<class T, class E>
 auto error(E e)
-    -> decltype(detail::make_error<T>(typename std::conditional_t<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), identity_immediate())) {
-    return      detail::make_error<T>(typename std::conditional_t<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), identity_immediate());
+    -> decltype(detail::make_error<T>(typename std::conditional_t<rxcpp::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), identity_immediate())) {
+    return      detail::make_error<T>(typename std::conditional_t<rxcpp::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), identity_immediate());
 }
 /*! @copydoc rx-error.hpp
  */
 template<class T, class E, class Coordination>
 auto error(E e, Coordination cn)
-    -> decltype(detail::make_error<T>(typename std::conditional_t<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), std::move(cn))) {
-    return      detail::make_error<T>(typename std::conditional_t<std::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), std::move(cn));
+    -> decltype(detail::make_error<T>(typename std::conditional_t<rxcpp::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), std::move(cn))) {
+    return      detail::make_error<T>(typename std::conditional_t<rxcpp::is_same_v<rxu::error_ptr, rxu::decay_t<E>>, detail::throw_ptr_tag, detail::throw_instance_tag>(), std::move(e), std::move(cn));
 }
 
 }

--- a/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
@@ -46,7 +46,7 @@ struct is_iterable
     template<class CC>
     static not_void check(...);
 
-    static const bool value = !std::is_same_v<decltype(check<collection_type>(0)), not_void>;
+    static const bool value = !rxcpp::is_same_v<decltype(check<collection_type>(0)), not_void>;
 };
 
 template<class Collection>

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
 project(rxcpp VERSION 2.2.4 LANGUAGES C CXX)
+set(CMAKE_CXX_STANDARD 14)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 


### PR DESCRIPTION
... in view of >=C++17's `std::is_same_v`

see also post-PR discussion at: https://github.com/ReactiveX/RxCpp/pull/572#issuecomment-1066465190-permalink

I tried to keep it as non-intrusive as possible and defined a `rxcpp::is_same_v` template pair in `rx-trace.cpp` since this seems to be the place that most (all?) of the other includes reference. Needed the `static constexpr bool ...` because C++14 does not allow for 'inline' and since `is_same_v` is a value and not type trait*.

@guhwanbae @kirkshoop hope and please let me know if this helps with the issue mentioned above.



P.S. *I noticed that the build times are quite large (possibly because of SFINAE, enable_ifs, etc.). Would be worthwhile to perhaps consider moving RxCpp to the current standard  (C++20)??  ... more features (concepts), lots of goodies, ranges (that seem to be similar/related to RxCpp), simpler/more succinct code, and faster compile-times. Food for thought.